### PR TITLE
Backup dir wp content

### DIFF
--- a/admin/class-boldgrid-backup-admin-backup-dir.php
+++ b/admin/class-boldgrid-backup-admin-backup-dir.php
@@ -313,8 +313,12 @@ class Boldgrid_Backup_Admin_Backup_Dir {
 			/*
 			 * Create the directory and all applicable files needed within for security,
 			 * such as .htaccess / etc.
+			 *
+			 * If directory is the wp-content directory, add additional random characters so that
+			 * the backup directory is not simply wp-content/boldgrid_backup.
 			 */
-			$possible_dir    .= DIRECTORY_SEPARATOR . 'boldgrid_backup';
+			$append           = $possible_dir !== WP_CONTENT_DIR ? '' : '_' . wp_generate_password( 12, false );
+			$possible_dir    .= DIRECTORY_SEPARATOR . 'boldgrid_backup' . $append;
 			$backup_directory = $this->create( $possible_dir );
 			if ( ! $backup_directory ) {
 				continue;

--- a/admin/class-boldgrid-backup-admin-backup-dir.php
+++ b/admin/class-boldgrid-backup-admin-backup-dir.php
@@ -317,7 +317,7 @@ class Boldgrid_Backup_Admin_Backup_Dir {
 			 * If directory is the wp-content directory, add additional random characters so that
 			 * the backup directory is not simply wp-content/boldgrid_backup.
 			 */
-			$append           = $possible_dir !== WP_CONTENT_DIR ? '' : '_' . wp_generate_password( 12, false );
+			$append           = WP_CONTENT_DIR !== $possible_dir ? '' : '_' . wp_generate_password( 12, false );
 			$possible_dir    .= DIRECTORY_SEPARATOR . 'boldgrid_backup' . $append;
 			$backup_directory = $this->create( $possible_dir );
 			if ( ! $backup_directory ) {

--- a/readme.txt
+++ b/readme.txt
@@ -76,6 +76,10 @@ The following features are available, of which you can find additional info for 
 
 == Changelog ==
 
+= 1.8.1 In progress =
+
+* Update: When storing backups in wp-content dir, make "boldgrid_backup" dir name more unique.
+
 = 1.8.0 =
 
 Release date: Feb 14th, 2019


### PR DESCRIPTION
**Testing...**

Make sure you get _wp-content/boldgrid_backup_RANDOM_ rather than _wp-content/boldgrid_backup_.

1. Comment out this line: https://github.com/BoldGrid/boldgrid-backup/blob/master/admin/class-boldgrid-backup-admin-backup-dir.php#L248
2. Delete your boldgrid_backup_settings options
3. Go into your backup settings and check your backup dir.