### PR TITLE
Site Check notification update

### DIFF
--- a/admin/class-boldgrid-backup-admin-archive.php
+++ b/admin/class-boldgrid-backup-admin-archive.php
@@ -540,6 +540,7 @@ class Boldgrid_Backup_Admin_Archive {
 			$archive_key      = isset( $archive_info['key'] ) ? $archive_info['key'] : null;
 			$cron_secret      = $this->core->cron->get_cron_secret();
 			$siteurl          = site_url();
+			$site_title       = get_bloginfo( 'name' );
 			$restore_cmd      = http_build_query(
 				[
 					'mode'             => 'restore',
@@ -548,7 +549,7 @@ class Boldgrid_Backup_Admin_Archive {
 					'secret'           => $cron_secret,
 					'archive_key'      => $archive_key,
 					'archive_filename' => $archive_filename,
-					'site_title'       => get_bloginfo( 'name' ),
+					'site_title'       => $site_title,
 				],
 				'',
 				' '
@@ -560,6 +561,7 @@ class Boldgrid_Backup_Admin_Archive {
 				'cron_secret' => $cron_secret,
 				'filepath'    => $archive_filepath,
 				'siteurl'     => $siteurl,
+				'site_title'  => $site_title,
 				'restore_cmd' => $this->core->cron->get_cron_command() . ' "' . dirname( __DIR__ ) .
 					'/boldgrid-backup-cron.php" ' . $restore_cmd,
 				'timestamp'   => time(),

--- a/cli/class-site-check.php
+++ b/cli/class-site-check.php
@@ -233,7 +233,9 @@ class Site_Check {
 	public static function send_notification() {
 		$recipient = Info::get_info()['site_title'] . ' <' . Info::get_email_arg() . '>';
 		$subject   = 'Failed Site Check for ' . Info::get_info()['siteurl'];
-		$message   = "A site Check has failed.  You should check your site and can perform a manual restoration, if needed.\r\n\r\nYou can manage notifications in your WordPress admin panel, under BoldGrid Backup Settings.\r\n\r\nFor assistance, please visit: https://www.boldgrid.com/support/boldgrid-backup/what-to-do-when-boldgrid-backup-site-check-fails/\r\n";
+		$message   = "A Site Check has failed.  You should check your site and can perform a manual restoration.\r\n\r\nFor help, please visit: https://www.boldgrid.com/support/boldgrid-backup/what-to-do-when-boldgrid-backup-site-check-fails/\r\n\r\nYou can manage notifications in your WordPress admin panel, under BoldGrid Backup Settings at:\r\n" .
+			Info::get_info()['siteurl'] .
+			"/wp-admin/admin.php?page=boldgrid-backup-settings\r\n";
 		Log::write( 'Sending email notification for failed site check to "' . $recipient . '".', LOG_INFO );
 
 		$result = json_decode( self::$wp_test_result, true );

--- a/cli/class-site-check.php
+++ b/cli/class-site-check.php
@@ -233,11 +233,14 @@ class Site_Check {
 	public static function send_notification() {
 		$recipient = Info::get_info()['site_title'] . ' <' . Info::get_email_arg() . '>';
 		$subject   = 'Failed Site Check for ' . Info::get_info()['siteurl'];
-		$message   = "A site Check has failed.  You should check your site and can perform a manual restoration, if needed.\r\n\r\nFor assistance, please visit: https://www.boldgrid.com/support/\r\n";
+		$message   = "A site Check has failed.  You should check your site and can perform a manual restoration, if needed.\r\n\r\nYou can manage notifications in your WordPress admin panel, under BoldGrid Backup Settings.\r\n\r\nFor assistance, please visit: https://www.boldgrid.com/support/boldgrid-backup/what-to-do-when-boldgrid-backup-site-check-fails/\r\n";
 		Log::write( 'Sending email notification for failed site check to "' . $recipient . '".', LOG_INFO );
 
-		if ( ! empty( json_decode( self::$wp_test_result, true ) ) ) {
-			$message .= "\r\nError information:\r\n" . self::$wp_test_result . "\r\n";
+		$result = json_decode( self::$wp_test_result, true );
+
+		if ( ! empty( $result['error']['message'] ) ) {
+			$message .= "\r\nError message:\r\n" . $result['error']['message'] . ' in ' . $result['error']['file'] . ' on line ' .
+				$result['error']['line'] . "\r\n";
 		}
 
 		echo 'Info: Sending notification email to "' . $recipient . '".' . PHP_EOL;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 4.4
 Tested up to: 5.2
 Requires PHP: 5.4
-Stable tag: 1.9.3
+Stable tag: 1.10.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -83,14 +83,10 @@ We also suggest joining our [Team Orange User Group community](https://www.faceb
 
 == Changelog ==
 
-= 1.10.0-alpha.2 In progress =
+= 1.10.0 In progress =
 
+* Update:      Updated content for the failed Site Check email notification message.
 * Update:      Removed duplicate build for toggles dependency.
-
-= 1.10.0-alpha.1 =
-
-Release date:  May 21, 2019
-
 * New feature: Added settings section, logging, and email notifications for Site Check (bgbkup-cli).
 * Bug fix:     Ensure archive exists before attempting to upload via ftp.
 


### PR DESCRIPTION
To test:
* [x] Edit a PHP file to create a syntax error.
* [x] Run the command (in directory "wp-content/plugins/boldgrid-backup/cli/") `php bgbkup-cli.php check notify email=$USER@boldgrid.com`
* [ ] Check for an email and review the contents.  There will be a link to the GitHub Wiki page for help and a link to BoldGrid Backup Settings for the site.
