### PR TITLE
Replaced cbschuld/browser.php with a custom solution to avoid class conflicts.  Fixes #86

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,7 @@
     "require": {
         "boldgrid/library": "2.*",
         "ifsnop/mysqldump-php" : "2.*",
-        "phpseclib/phpseclib" : "~2.0",
-        "cbschuld/browser.php" : "~1.0-dev"
+        "phpseclib/phpseclib" : "~2.0"
     },
     "require-dev": {
         "lox/xhprof": "dev-master"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf4347cd90025fba0e73f75f54471bf2",
+    "content-hash": "04ed8193c7289a89265a5f333b66d74a",
     "packages": [
         {
             "name": "boldgrid/library",
@@ -55,49 +55,6 @@
             ],
             "description": "The BoldGrid Library for shared code used in official BoldGrid plugins and themes.",
             "time": "2019-07-25T18:36:58+00:00"
-        },
-        {
-            "name": "cbschuld/browser.php",
-            "version": "1.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cbschuld/Browser.php.git",
-                "reference": "f5c5600237cb88b983b8c26811022e4b96523c14"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cbschuld/Browser.php/zipball/f5c5600237cb88b983b8c26811022e4b96523c14",
-                "reference": "f5c5600237cb88b983b8c26811022e4b96523c14",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": []
-            },
-            "autoload": {
-                "classmap": [
-                    "lib/Browser.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Schuld",
-                    "email": "chris@chrisschuld.com",
-                    "homepage": "http://chrisschuld.com"
-                }
-            ],
-            "description": "A PHP Class to detect a user's Browser",
-            "homepage": "http://chrisschuld.com/projects/browser-php-detecting-a-users-browser-from-php.html",
-            "keywords": [
-                "browser",
-                "detection",
-                "user agent"
-            ],
-            "time": "2019-06-19T17:24:22+00:00"
         },
         {
             "name": "ifsnop/mysqldump-php",
@@ -291,7 +248,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "cbschuld/browser.php": 20,
         "lox/xhprof": 20
     },
     "prefer-stable": false,

--- a/readme.txt
+++ b/readme.txt
@@ -134,6 +134,7 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 
 = 1.10.5 In progress =
 
+* Bug fix:     Replaced cbschuld/browser.php with a custom solution to avoid class conflicts.
 * Update:      Updated dependencies.
 
 = 1.10.4 =


### PR DESCRIPTION
To test: Go to the `wp-admin/admin.php?page=boldgrid-backup-tools` page and review the "Local Machine" section to see the "Browser" and "Operating System" values.

You should see something similar to the following:

`Browser: Chrome 75.0.3770.142`

`Operating System: Windows NT 10.0; Win64; x64`

or:

`Browser: Firefox 68.0`

`Operating System: Windows NT 10.0; Win64; x64; rv:68.0`
