### PR TITLE
Updated auto-rollback to use CLI restore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 
 script:
   - find . -name composer -prune -o -name node_modules -prune -o -name '*.php' -exec php -lf {} \; > /dev/null
-  - phpunit --debug --coverage-clover=coverage.xml
+  - phpunit --debug --coverage-clover=coverage.xml --group ajax
   - yarn run php-codesniffer
   - yarn run js-lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 
 script:
   - find . -name composer -prune -o -name node_modules -prune -o -name '*.php' -exec php -lf {} \; > /dev/null
-  - phpunit --debug --coverage-clover=coverage.xml --group ajax
+  - phpunit --debug --coverage-clover=coverage.xml
   - yarn run php-codesniffer
   - yarn run js-lint
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_script:
 script:
   - find . -name composer -prune -o -name node_modules -prune -o -name '*.php' -exec php -lf {} \; > /dev/null
   - phpunit --debug --coverage-clover=coverage.xml
+  - phpunit --debug --group ajax
   - yarn run php-codesniffer
   - yarn run js-lint
 

--- a/admin/class-boldgrid-backup-admin-auto-rollback.php
+++ b/admin/class-boldgrid-backup-admin-auto-rollback.php
@@ -1095,4 +1095,17 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 
 		return $value;
 	}
+
+	/**
+	 * Callback function for canceling a pending rollback from the cli process.
+	 *
+	 * This admin-ajax call is unprovileged, so that the CLI script can make the call.
+	 * Nobody will be trying to cancel rollbacks (with a 15-minute window) anyways.
+	 *
+	 * @since 1.10.7
+	 */
+	public function wp_ajax_cli_cancel() {
+		$this->cancel();
+		wp_die();
+	}
 }

--- a/admin/class-boldgrid-backup-admin-auto-rollback.php
+++ b/admin/class-boldgrid-backup-admin-auto-rollback.php
@@ -1079,8 +1079,8 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 	 *
 	 * @since 1.7.0
 	 *
-	 * @param  array|false WordPress option value for "boldgrid_backup_pending_rollback".
-	 * @param  string      Option name.
+	 * @param  array|false $value  WordPress option value for "boldgrid_backup_pending_rollback".
+	 * @param  string      $option Option name.
 	 * @return array|false
 	 */
 	public function validate_rollback_option( $value, $option ) {

--- a/admin/class-boldgrid-backup-admin-auto-rollback.php
+++ b/admin/class-boldgrid-backup-admin-auto-rollback.php
@@ -1100,12 +1100,19 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 	 * Callback function for canceling a pending rollback from the cli process.
 	 *
 	 * This admin-ajax call is unprovileged, so that the CLI script can make the call.
+	 * The only validation that we use is the backup identifier.
 	 * Nobody will be trying to cancel rollbacks (with a 15-minute window) anyways.
 	 *
 	 * @since 1.10.7
 	 */
 	public function wp_ajax_cli_cancel() {
-		$this->cancel();
-		wp_die();
+		$backup_id_match = ! empty( $_GET['backup_id'] ) && $this->core->get_backup_identifier() === sanitize_key( $_GET['backup_id'] ); // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+
+		if ( $backup_id_match ) {
+			$this->cancel();
+			wp_send_json_success( __( 'Rollback canceled', 'boldgrid-backup' ) );
+		} else {
+			wp_send_json_error( __( 'Invalid arguments', 'boldgrid-backup' ), 400 );
+		}
 	}
 }

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -278,12 +278,13 @@ class Boldgrid_Backup_Admin_Cron {
 			$deadline = $time_5_minutes_later;
 		}
 
+		$settings         = $this->core->settings->get_settings();
+		$backup_directory = $this->core->backup_dir->get();
+
 		// Build cron job line in crontab format.
 		$entry = date( $minute . ' ' . $hour, $deadline ) . ' * * ' . date( 'w' ) . ' ' . $this->cron_command . ' "' .
-			dirname( dirname( __FILE__ ) ) . '/boldgrid-backup-cron.php" mode=restore siteurl=' .
-			get_site_url() . ' id=' . $this->core->get_backup_identifier() . ' secret=' .
-			$this->get_cron_secret() . ' archive_key=' . $archive_key .
-			' archive_filename=' . $archive_filename;
+			dirname( dirname( __FILE__ ) ) . '/cli/bgbkup-cli.php" mode=restore restore notify email=' . $settings['notification_email'] .
+			' zip=' . $backup_directory . '/' . $archive_filename;
 
 		// If not Windows, then also silence the cron job.
 		if ( ! $this->core->test->is_windows() ) {
@@ -553,7 +554,7 @@ class Boldgrid_Backup_Admin_Cron {
 		if ( '' === $mode ) {
 			$pattern .= 'boldgrid-backup-cron.php" mode=';
 		} elseif ( 'restore' === $mode ) {
-			$pattern .= 'boldgrid-backup-cron.php" mode=restore';
+			$pattern .= 'cli/bgbkup-cli.php" mode=restore';
 		} elseif ( true !== $mode ) {
 			$pattern .= $mode;
 		}

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -280,11 +280,12 @@ class Boldgrid_Backup_Admin_Cron {
 
 		$settings         = $this->core->settings->get_settings();
 		$backup_directory = $this->core->backup_dir->get();
+		$backup_id        = $this->core->get_backup_identifier();
 
 		// Build cron job line in crontab format.
 		$entry = date( $minute . ' ' . $hour, $deadline ) . ' * * ' . date( 'w' ) . ' ' . $this->cron_command . ' "' .
 			dirname( dirname( __FILE__ ) ) . '/cli/bgbkup-cli.php" mode=restore restore notify email=' . $settings['notification_email'] .
-			' zip=' . $backup_directory . '/' . $archive_filename;
+			' backup_id=' . $backup_id . ' zip=' . $backup_directory . '/' . $archive_filename;
 
 		// If not Windows, then also silence the cron job.
 		if ( ! $this->core->test->is_windows() ) {

--- a/cli/class-site-restore.php
+++ b/cli/class-site-restore.php
@@ -133,6 +133,7 @@ class Site_Restore {
 	 * @see self::restore_database()
 	 * @see self::increment_restore_attempts()
 	 * @see \Boldgrid\Backup\Cli\Log::write()
+	 * @see self::cancel_rollback()
 	 *
 	 * @return bool;
 	 */
@@ -154,6 +155,8 @@ class Site_Restore {
 			ignore_user_abort( true );
 			$this->set_time_limit();
 			$success = $this->restore_files() && $this->restore_database();
+
+			$this->cancel_rollback();
 		}
 
 		$this->increment_restore_attempts();
@@ -340,5 +343,17 @@ class Site_Restore {
 		file_put_contents( Info::get_results_filepath(), json_encode( $results ) );
 
 		Info::set_info_item( 'restore_attempts', $results['restore_attempts'] );
+	}
+
+	/**
+	 * Cancel any rollback scheduled.
+	 *
+	 * @since 1.10.7
+	 * @access private
+	 */
+	private function cancel_rollback() {
+		require dirname( dirname( __FILE__ ) ) . '/cron/class-boldgrid-backup-url-helper.php';
+		$url = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback';
+		( new Boldgrid_Backup_Url_Helper() )->call_url( $url );
 	}
 }

--- a/cli/class-site-restore.php
+++ b/cli/class-site-restore.php
@@ -353,7 +353,7 @@ class Site_Restore {
 	 */
 	private function cancel_rollback() {
 		require_once dirname( dirname( __FILE__ ) ) . '/cron/class-boldgrid-backup-url-helper.php';
-		$url = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback';
-		( new \Boldgrid_Backup_Url_Helper() )->call_url( $url );
+		$url     = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback';
+		$success = ( new \Boldgrid_Backup_Url_Helper() )->call_url( $url, $status, $errorno, $error );
 	}
 }

--- a/cli/class-site-restore.php
+++ b/cli/class-site-restore.php
@@ -352,7 +352,7 @@ class Site_Restore {
 	 * @access private
 	 */
 	private function cancel_rollback() {
-		require dirname( dirname( __FILE__ ) ) . '/cron/class-boldgrid-backup-url-helper.php';
+		require_once dirname( dirname( __FILE__ ) ) . '/cron/class-boldgrid-backup-url-helper.php';
 		$url = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback';
 		( new Boldgrid_Backup_Url_Helper() )->call_url( $url );
 	}

--- a/cli/class-site-restore.php
+++ b/cli/class-site-restore.php
@@ -350,10 +350,13 @@ class Site_Restore {
 	 *
 	 * @since 1.10.7
 	 * @access private
+	 *
+	 * @see \Boldgrid\Backup\Cli\Info::get_arg_value()
 	 */
 	private function cancel_rollback() {
 		require_once dirname( dirname( __FILE__ ) ) . '/cron/class-boldgrid-backup-url-helper.php';
-		$url     = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback';
+		$url     = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback&backup_id=' .
+			Info::get_arg_value( 'backup_id' );
 		$success = ( new \Boldgrid_Backup_Url_Helper() )->call_url( $url, $status, $errorno, $error );
 	}
 }

--- a/cli/class-site-restore.php
+++ b/cli/class-site-restore.php
@@ -354,6 +354,6 @@ class Site_Restore {
 	private function cancel_rollback() {
 		require_once dirname( dirname( __FILE__ ) ) . '/cron/class-boldgrid-backup-url-helper.php';
 		$url = Info::get_info()['siteurl'] . '/wp-admin/admin-ajax.php?action=boldgrid_cli_cancel_rollback';
-		( new Boldgrid_Backup_Url_Helper() )->call_url( $url );
+		( new \Boldgrid_Backup_Url_Helper() )->call_url( $url );
 	}
 }

--- a/includes/class-boldgrid-backup.php
+++ b/includes/class-boldgrid-backup.php
@@ -325,6 +325,12 @@ class Boldgrid_Backup {
 			'wp_ajax_cancel'
 		);
 
+		// Add a custom action to handle AJAX callback for canceling a pending rollback from the CLI restoration script.
+		$this->loader->add_action(
+			'wp_ajax_nopriv_boldgrid_cli_cancel_rollback', $plugin_admin_core->auto_rollback,
+			'wp_ajax_cli_cancel'
+		);
+
 		if ( $plugin_admin_core->test->run_functionality_tests() ) {
 			$this->loader->add_action( 'admin_notices', $plugin_admin_core->auto_rollback, 'notice_backup_show' );
 		}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,8 +7,8 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
-			<directory prefix="test-" suffix=".php">./tests/</directory>
+		<testsuite name="tests">
+			<directory suffix=".php">./tests/</directory>
 		</testsuite>
 	</testsuites>
 	<filter>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,4 +16,9 @@
 			<directory>./</directory>
 		</whitelist>
 	</filter>
+	<groups>
+		<exclude>
+			<group>ajax</group>
+		</exclude>
+	</groups>
 </phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,12 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 
 == Changelog ==
 
+= 1.10.7 In progress =
+
+Release date: ?
+
+* Update:      Updated auto-rollback to use the CLI restoration process.
+
 = 1.10.6 =
 
 Release date: August 1st, 2019

--- a/tests/admin/test-class-boldgrid-backup-admin-ajax.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-ajax.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File: test-class-boldgrid-backup-admin-auto-rollback.php
+ * File: test-class-boldgrid-backup-admin-ajax.php
  *
  * @link https://www.boldgrid.com
  * @since     1.10.7
@@ -9,14 +9,19 @@
  * @subpackage Boldgrid_Backup/tests/admin
  * @copyright  BoldGrid
  * @author     BoldGrid <support@boldgrid.com>
+ *
+ * // phpcs:disable Generic.PHP.NoSilencedErrors,WordPress.VIP
  */
 
 /**
- * Class: Test_Boldgrid_Backup_Admin_Test
+ * Class: Test_Boldgrid_Backup_Admin_Ajax
  *
  * @since 1.10.7
+ *
+ * @group ajax
+ * @runTestsInSeparateProcesses
  */
-class Test_Boldgrid_Backup_Admin_Auto_Rollback extends WP_UnitTestCase {
+class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 	/**
 	 * Setup.
 	 *
@@ -32,17 +37,18 @@ class Test_Boldgrid_Backup_Admin_Auto_Rollback extends WP_UnitTestCase {
 	 * @since 1.10.7
 	 */
 	public function test_wp_ajax_cli_cancel_success() {
+		global $_GET; // phpcs:ignore
 		$_GET['backup_id'] = $this->core->get_backup_identifier();
 
 		try {
-			$this->_handleAjax( 'boldgrid_cli_cancel_rollback' );
+			@$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
 		} catch ( WPAjaxDieStopException $e ) {
 			echo null; // Do nothing.
 		}
 
 		$response = json_decode( $this->_last_response );
 
-		$this->assertInternalType( 'object', $response ); // Should be an object; not FALSE.
+		$this->assertInternalType( 'object', $response ); // Should be an object.
 		$this->assertObjectHasAttribute( 'success', $response ); // Should have "success".
 		$this->assertTrue( $response->success ); // "success" should be TRUE.
 		$this->assertObjectHasAttribute( data, $response ); // Should have "data".
@@ -55,15 +61,18 @@ class Test_Boldgrid_Backup_Admin_Auto_Rollback extends WP_UnitTestCase {
 	 * @since 1.10.7
 	 */
 	public function test_wp_ajax_cli_cancel_failure() {
+		global $_GET; // phpcs:ignore
+		unset( $_GET['backup_id'] );
+
 		try {
-			$this->_handleAjax( 'boldgrid_cli_cancel_rollback' );
+			@$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
 		} catch ( WPAjaxDieStopException $e ) {
 			echo null; // Do nothing.
 		}
 
 		$response = json_decode( $this->_last_response );
 
-		$this->assertInternalType( 'object', $response ); // Should be an object; not FALSE.
+		$this->assertInternalType( 'object', $response ); // Should be an object.
 		$this->assertObjectHasAttribute( 'success', $response ); // Should have "success".
 		$this->assertFalse( $response->success ); // "success" should be FALSE.
 		$this->assertObjectHasAttribute( data, $response ); // Should have "data".

--- a/tests/admin/test-class-boldgrid-backup-admin-ajax.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-ajax.php
@@ -28,6 +28,11 @@ class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 	 * @since 1.10.7
 	 */
 	public function setUp() {
+		parent::setup();
+
+		require_once dirname( dirname( __DIR__ ) ) . '/includes/class-boldgrid-backup.php';
+		( new Boldgrid_Backup() )->run();
+
 		$this->core = new Boldgrid_Backup_Admin_Core();
 	}
 
@@ -42,11 +47,8 @@ class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 
 		update_option( 'boldgrid_backup_pending_rollback', 'test' );
 
-		try {
-			@$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
-		} catch ( WPAjaxDieStopException $e ) {
-			echo null; // Do nothing.
-		}
+		$this->setExpectedException( 'WPAjaxDieContinueException' );
+		$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
 
 		// This option was given a value above, and the cancel rollback method should have deleted it.
 		$this->assertEmpty( get_option( 'boldgrid_backup_pending_rollback' ) );
@@ -56,7 +58,7 @@ class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 		$this->assertInternalType( 'object', $response ); // Should be an object.
 		$this->assertObjectHasAttribute( 'success', $response ); // Should have "success".
 		$this->assertTrue( $response->success ); // "success" should be TRUE.
-		$this->assertObjectHasAttribute( data, $response ); // Should have "data".
+		$this->assertObjectHasAttribute( 'data', $response ); // Should have "data".
 		$this->assertEquals( 'Rollback canceled', $response->data ); // "data" is a string; must match expected string.
 	}
 
@@ -71,11 +73,8 @@ class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 
 		update_option( 'boldgrid_backup_pending_rollback', 'test' );
 
-		try {
-			@$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
-		} catch ( WPAjaxDieStopException $e ) {
-			echo null; // Do nothing.
-		}
+		$this->setExpectedException( 'WPAjaxDieContinueException' );
+		$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
 
 		/*
 		 * This option was given a value above, and because the cancel rollback method failed, the

--- a/tests/admin/test-class-boldgrid-backup-admin-ajax.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-ajax.php
@@ -40,11 +40,16 @@ class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 		global $_GET; // phpcs:ignore
 		$_GET['backup_id'] = $this->core->get_backup_identifier();
 
+		update_option( 'boldgrid_backup_pending_rollback', 'test' );
+
 		try {
 			@$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
 		} catch ( WPAjaxDieStopException $e ) {
 			echo null; // Do nothing.
 		}
+
+		// This option was given a value above, and the cancel rollback method should have deleted it.
+		$this->assertEmpty( get_option( 'boldgrid_backup_pending_rollback' ) );
 
 		$response = json_decode( $this->_last_response );
 

--- a/tests/admin/test-class-boldgrid-backup-admin-ajax.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-ajax.php
@@ -69,11 +69,19 @@ class Test_Boldgrid_Backup_Admin_Ajax extends WP_Ajax_UnitTestCase {
 		global $_GET; // phpcs:ignore
 		unset( $_GET['backup_id'] );
 
+		update_option( 'boldgrid_backup_pending_rollback', 'test' );
+
 		try {
 			@$this->_handleAjax( 'nopriv_boldgrid_cli_cancel_rollback' );
 		} catch ( WPAjaxDieStopException $e ) {
 			echo null; // Do nothing.
 		}
+
+		/*
+		 * This option was given a value above, and because the cancel rollback method failed, the
+		 * value should still be the same.
+		 */
+		$this->assertEquals( 'test', get_option( 'boldgrid_backup_pending_rollback' ) );
 
 		$response = json_decode( $this->_last_response );
 

--- a/tests/admin/test-class-boldgrid-backup-admin-auto-rollback.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-auto-rollback.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * File: test-class-boldgrid-backup-admin-auto-rollback.php
+ *
+ * @link https://www.boldgrid.com
+ * @since     1.10.7
+ *
+ * @package    Boldgrid_Backup
+ * @subpackage Boldgrid_Backup/tests/admin
+ * @copyright  BoldGrid
+ * @author     BoldGrid <support@boldgrid.com>
+ */
+
+/**
+ * Class: Test_Boldgrid_Backup_Admin_Test
+ *
+ * @since 1.10.7
+ */
+class Test_Boldgrid_Backup_Admin_Auto_Rollback extends WP_UnitTestCase {
+	/**
+	 * Setup.
+	 *
+	 * @since 1.10.7
+	 */
+	public function setUp() {
+		$this->core = new Boldgrid_Backup_Admin_Core();
+	}
+
+	/**
+	 * Test wp_ajax_cli_cancel for success.
+	 *
+	 * @since 1.10.7
+	 */
+	public function test_wp_ajax_cli_cancel_success() {
+		$_GET['backup_id'] = $this->core->get_backup_identifier();
+
+		try {
+			$this->_handleAjax( 'boldgrid_cli_cancel_rollback' );
+		} catch ( WPAjaxDieStopException $e ) {
+			echo null; // Do nothing.
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertInternalType( 'object', $response ); // Should be an object; not FALSE.
+		$this->assertObjectHasAttribute( 'success', $response ); // Should have "success".
+		$this->assertTrue( $response->success ); // "success" should be TRUE.
+		$this->assertObjectHasAttribute( data, $response ); // Should have "data".
+		$this->assertEquals( 'Rollback canceled', $response->data ); // "data" is a string; must match expected string.
+	}
+
+	/**
+	 * Test wp_ajax_cli_cancel for failure.
+	 *
+	 * @since 1.10.7
+	 */
+	public function test_wp_ajax_cli_cancel_failure() {
+		try {
+			$this->_handleAjax( 'boldgrid_cli_cancel_rollback' );
+		} catch ( WPAjaxDieStopException $e ) {
+			echo null; // Do nothing.
+		}
+
+		$response = json_decode( $this->_last_response );
+
+		$this->assertInternalType( 'object', $response ); // Should be an object; not FALSE.
+		$this->assertObjectHasAttribute( 'success', $response ); // Should have "success".
+		$this->assertFalse( $response->success ); // "success" should be FALSE.
+		$this->assertObjectHasAttribute( data, $response ); // Should have "data".
+		$this->assertEquals( 'Invalid arguments', $response->data ); // "data" is a string; must match expected string.
+	}
+}


### PR DESCRIPTION
# Testing Instructors
Note: Use "Cron" as the scheduler.
1. [ ] Change a plugin to a lower version number, to stage an update.
2. [ ] Go to the Plugins page.
3. [ ] Create a full backup.
4. [ ] Update the plugin.
5. [ ] Break WordPress by adding a syntax error in `wp-config.php`.
6. [ ] In SSH, run `crontab -l` to list the cron jobs.
7. [ ] Run the script to restore that is in the crontab, minus the `> /dev/null 2>&1` part.
8. [ ] Check the crontab to see if the restore line was deleted.
