### PR TITLE
Fixed "Use of undefined constant STDERR" warning for bgbkup-cli.

### DIFF
--- a/cli/class-info.php
+++ b/cli/class-info.php
@@ -125,6 +125,10 @@ class Info {
 	 */
 	public static function print_errors() {
 		if ( self::has_errors() ) {
+			if ( ! defined( 'STDERR' ) ) {
+				define( 'STDERR', fopen( 'php://stderr', 'w' ) );
+			}
+
 			fwrite( STDERR, implode( PHP_EOL, self::$info['errors'] ) . PHP_EOL );
 		}
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,10 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 
 == Changelog ==
 
+= 1.10.7 In progress =
+
+* Bug fix:     Fixed "Use of undefined constant STDERR" warning for bgbkup-cli.
+
 = 1.10.6 =
 
 Release date: August 1st, 2019


### PR DESCRIPTION
To test: Run `php -d register_argc_argv="1" -qf "~/public_html/wp-content/plugins/boldgrid-backup/cli/bgbkup-cli.php" check log=1` and look for PHP warnings.
