### PR TITLE
Reload on backup

### DIFF
--- a/admin/class-boldgrid-backup-admin-auto-rollback.php
+++ b/admin/class-boldgrid-backup-admin-auto-rollback.php
@@ -263,9 +263,6 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 		wp_localize_script( $handle, 'boldgridBackupCustomizer', $translations );
 		wp_enqueue_script( $handle );
 
-		// Needed to show the "in progress" bar in the customizer.
-		wp_enqueue_script( 'jquery-ui-progressbar' );
-
 		$this->enqueue_backup_scripts();
 
 		$this->enqueue_rollback_scripts();

--- a/admin/class-boldgrid-backup-admin-auto-rollback.php
+++ b/admin/class-boldgrid-backup-admin-auto-rollback.php
@@ -225,25 +225,7 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 			false
 		);
 
-		$access_type          = get_filesystem_method();
-		$archive_nonce        = wp_create_nonce( 'archive_auth' );
-		$localize_script_data = array(
-			'archiveNonce'              => $archive_nonce,
-			'accessType'                => $access_type,
-			'updateProtectionActivated' => $this->core->elements['update_protection_activated'],
-			'backupCreated'             => $this->core->lang['backup_created'],
-			'errorText'                 => esc_html__(
-				'There was an error processing your request.  Please reload the page and try again.',
-				'boldgrid-backup'
-			),
-		);
-		wp_localize_script( $handle, 'localizeScriptData', $localize_script_data );
-
 		wp_enqueue_script( $handle );
-
-		// Scripts required for showing backup in progress bar.
-		wp_enqueue_script( 'heartbeat' );
-		wp_enqueue_script( 'jquery-ui-progressbar' );
 	}
 
 	/**
@@ -280,6 +262,9 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 		);
 		wp_localize_script( $handle, 'boldgridBackupCustomizer', $translations );
 		wp_enqueue_script( $handle );
+
+		// Needed to show the "in progress" bar in the customizer.
+		wp_enqueue_script( 'jquery-ui-progressbar' );
 
 		$this->enqueue_backup_scripts();
 
@@ -875,8 +860,9 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 		 * 1.6.0 so that we can uniquely identify this notice on the page.
 		 */
 		$backup_button = include BOLDGRID_BACKUP_PATH . '/admin/partials/boldgrid-backup-admin-backup-button.php';
+		$in_progress   = Boldgrid_Backup_Admin_In_Progress_Data::get_markup();
 		$notice        = $this->notice_backup_get();
-		do_action( 'boldgrid_backup_notice', $notice . $backup_button, 'notice notice-warning is-dismissible boldgrid-backup-protect-now' );
+		do_action( 'boldgrid_backup_notice', $notice . $backup_button . $in_progress, 'notice notice-warning is-dismissible boldgrid-backup-protect-now' );
 	}
 
 	/**
@@ -1143,7 +1129,8 @@ class Boldgrid_Backup_Admin_Auto_Rollback {
 			// You're not protected, make a backup first.
 			$notice        = $this->notice_backup_get();
 			$backup_button = include BOLDGRID_BACKUP_PATH . '/admin/partials/boldgrid-backup-admin-backup-button.php';
-			$notice        = '<div class="notice notice-warning is-dismissible boldgrid-backup-protect-now">' . $notice . $backup_button . '</div>';
+			$in_progress   = Boldgrid_Backup_Admin_In_Progress_Data::get_markup();
+			$notice        = '<div class="notice notice-warning is-dismissible boldgrid-backup-protect-now">' . $notice . $backup_button . $in_progress . '</div>';
 		}
 
 		wp_send_json_success( $notice );

--- a/admin/class-boldgrid-backup-admin-core.php
+++ b/admin/class-boldgrid-backup-admin-core.php
@@ -2352,22 +2352,18 @@ class Boldgrid_Backup_Admin_Core {
 
 		$archive_info = $this->archive_files( true );
 
-		if ( ! $this->is_archiving_update_protection ) {
-			$message = include BOLDGRID_BACKUP_PATH . '/admin/partials/boldgrid-backup-admin-backup.php';
-			$this->notice->add_user_notice( $message['message'], $message['class'] );
-			wp_send_json_success(
-				array(
-					'callback' => 'reload',
-				)
-			);
-		} else {
+		if ( $this->is_archiving_update_protection ) {
 			update_site_option( 'boldgrid_backup_pending_rollback', $archive_info );
-			wp_send_json_success(
-				array(
-					'callback' => 'updateProtectionEnabled',
-				)
-			);
 		}
+
+		/*
+		 * Finish.
+		 *
+		 * Normally we'd give the user a notice that the backup has been completed. However, since
+		 * 1.12.0, we are no longer waiting for this ajax call to complete. The "in progress" bar
+		 * will give the user any updates they need.
+		 */
+		wp_send_json_success();
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin.php
+++ b/admin/class-boldgrid-backup-admin.php
@@ -120,11 +120,11 @@ class Boldgrid_Backup_Admin {
 		$spinner     = '<span class="spinner inline"></span> ';
 		$dots        = ' ...';
 		$translation = array(
-			'is_premium'                  => ( true === $this->config->get_is_premium() ? 'true' : 'false' ),
-			'lang'                        => $this->config->lang,
-			'spinner_loading'             => $spinner . __( 'Loading', 'boldgrid-backup' ) . $dots,
-			'spinner'                     => $spinner,
-			'get_premium_url'             => Boldgrid_Backup_Admin_Go_Pro::$url,
+			'is_premium'      => ( true === $this->config->get_is_premium() ? 'true' : 'false' ),
+			'lang'            => $this->config->lang,
+			'spinner_loading' => $spinner . __( 'Loading', 'boldgrid-backup' ) . $dots,
+			'spinner'         => $spinner,
+			'get_premium_url' => Boldgrid_Backup_Admin_Go_Pro::$url,
 		);
 
 		wp_localize_script( 'boldgrid-backup-admin', 'BoldGridBackupAdmin', $translation );

--- a/admin/class-boldgrid-backup-admin.php
+++ b/admin/class-boldgrid-backup-admin.php
@@ -92,6 +92,8 @@ class Boldgrid_Backup_Admin {
 	 * @since 1.0
 	 */
 	public function enqueue_styles() {
+		$core = apply_filters( 'boldgrid_backup_get_core', null );
+
 		/*
 		 * An instance of this class should be passed to the run() function
 		 * defined in Boldgrid_Backup_Loader as all of the hooks are defined
@@ -118,11 +120,11 @@ class Boldgrid_Backup_Admin {
 		$spinner     = '<span class="spinner inline"></span> ';
 		$dots        = ' ...';
 		$translation = array(
-			'is_premium'      => ( true === $this->config->get_is_premium() ? 'true' : 'false' ),
-			'lang'            => $this->config->lang,
-			'spinner_loading' => $spinner . __( 'Loading', 'boldgrid-backup' ) . $dots,
-			'spinner'         => $spinner,
-			'get_premium_url' => Boldgrid_Backup_Admin_Go_Pro::$url,
+			'is_premium'                  => ( true === $this->config->get_is_premium() ? 'true' : 'false' ),
+			'lang'                        => $this->config->lang,
+			'spinner_loading'             => $spinner . __( 'Loading', 'boldgrid-backup' ) . $dots,
+			'spinner'                     => $spinner,
+			'get_premium_url'             => Boldgrid_Backup_Admin_Go_Pro::$url,
 		);
 
 		wp_localize_script( 'boldgrid-backup-admin', 'BoldGridBackupAdmin', $translation );
@@ -139,10 +141,12 @@ class Boldgrid_Backup_Admin {
 			false
 		);
 		$translation = array(
-			'archive_file_size'       => __( 'Archive file size: ', 'boldgrid_backup' ),
-			'size_before_compression' => __( 'File size before compression: ', 'boldgrid-backup' ),
-			'adding_tables'           => __( 'Adding tables.', 'boldgrid-backup' ),
-			'completing_database'     => __( 'Completing database backup...', 'boldgrid-backup' ),
+			'archive_file_size'           => __( 'Archive file size: ', 'boldgrid_backup' ),
+			'size_before_compression'     => __( 'File size before compression: ', 'boldgrid-backup' ),
+			'adding_tables'               => __( 'Adding tables.', 'boldgrid-backup' ),
+			'completing_database'         => __( 'Completing database backup...', 'boldgrid-backup' ),
+			'update_protection_activated' => $core->elements['update_protection_activated'],
+			'backup_created'              => $core->lang['backup_created'],
 		);
 		wp_localize_script( $handle, 'BoldGridBackupAdminInProgress', $translation );
 		wp_enqueue_script( $handle );

--- a/admin/class-boldgrid-backup-admin.php
+++ b/admin/class-boldgrid-backup-admin.php
@@ -151,6 +151,12 @@ class Boldgrid_Backup_Admin {
 		wp_localize_script( $handle, 'BoldGridBackupAdminInProgress', $translation );
 		wp_enqueue_script( $handle );
 
+		// The "In Progress" script relies on the heartbeat.
+		wp_enqueue_script( 'heartbeat' );
+
+		// The "In Progress" script needs this progressbar script.
+		wp_enqueue_script( 'jquery-ui-progressbar' );
+
 		// Used by admin.js to highlight / bounce elements.
 		wp_enqueue_script( 'jquery-effects-core' );
 		wp_enqueue_script( 'jquery-effects-bounce' );

--- a/admin/css/boldgrid-backup-admin-folder-exclude.css
+++ b/admin/css/boldgrid-backup-admin-folder-exclude.css
@@ -94,7 +94,6 @@
 	left: 0px;
 	right: 0px;
 	padding: 0px 10px;
-	text-align: right;
 }
 .plugin-card-bottom #you_may_leave {
 	float: left;

--- a/admin/js/boldgrid-backup-admin-backup-now.js
+++ b/admin/js/boldgrid-backup-admin-backup-now.js
@@ -142,9 +142,9 @@ BOLDGRID.BACKUP.BackupNow = function( $ ) {
 		/*
 		 * Take action now that the ajax call to create a backup has been triggered.
 		 *
-		 * If we're on the Backup Archive's page page, reload the page. Within the "Backup Site Now"
-		 * modal, the user will be given a notice that their backup has started, and that the page will
-		 * refresh and display a progress bar.
+		 * If we're on the Backup Archive's page page, wait 3 seconds and reload the page. Within the
+		 * "Backup Site Now" modal, the user will be given a notice that their backup has started, and
+		 * that the page will refresh and display a progress bar.
 		 *
 		 * Else, trigger 'boldgrid_backup_initiated'. The only listener is in-progress.js. When a
 		 * backup has been initiated, it starts the WordPress Heartbeat and shows the in progress container.

--- a/admin/js/boldgrid-backup-admin-backup-now.js
+++ b/admin/js/boldgrid-backup-admin-backup-now.js
@@ -9,7 +9,7 @@
  * @param $ The jQuery object.
  */
 
-/* global ajaxurl,jQuery,localizeScriptData */
+/* global ajaxurl,jQuery,localizeScriptData,pagenow */
 
 var BOLDGRID = BOLDGRID || {};
 BOLDGRID.BACKUP = BOLDGRID.BACKUP || {};
@@ -18,14 +18,11 @@ BOLDGRID.BACKUP.BackupNow = function( $ ) {
 	'use strict';
 
 	var self = this,
-		lang = localizeScriptData,
 		$backupNowType = $( '[name="folder_exclusion_type"]' ),
 		$tablesType = $( '[name="table_inclusion_type"]' );
 
 	$( function() {
 		$( 'body' ).on( 'click', '#backup-site-now', self.backupNow );
-
-		$( 'body' ).on( 'boldgrid_backup_complete', self.updateProtectionEnabled );
 	} );
 
 	/**
@@ -38,14 +35,10 @@ BOLDGRID.BACKUP.BackupNow = function( $ ) {
 		// Declare variables.
 		var $this,
 			$backupSiteSection,
-			$backupSiteResults,
 			backupNonce,
 			wpHttpReferer,
 			isUpdating,
-			errorCallback,
-			successCallback,
 			data,
-			markup,
 			$folderExclude = $( '[name="folder_exclusion_exclude"]' ),
 			$folderInclude = $( '[name="folder_exclusion_include"]' ),
 			$tableInclude = $( '[name="include_tables[]"]' ),
@@ -74,9 +67,6 @@ BOLDGRID.BACKUP.BackupNow = function( $ ) {
 		// Create a context selector for the Backup Site Now section.
 		$backupSiteSection = $( '#backup-site-now-section' );
 
-		// Create a context selector for the Backup Site Now results.
-		$backupSiteResults = $( '#backup-site-now-results' );
-
 		$( '#TB_ajaxContent' )
 			.find( 'input' )
 			.attr( 'disabled', true )
@@ -96,66 +86,6 @@ BOLDGRID.BACKUP.BackupNow = function( $ ) {
 		isUpdating = $this.data( 'updating' );
 
 		$backupSiteSection.find( '.spinner' ).addClass( 'inline' );
-
-		/**
-		 * @summary backupNow error callback.
-		 *
-		 * @since 1.0
-		 *
-		 * @param object jqXHR
-		 * @param string textStatus
-		 * @param string errorThrown
-		 */
-		errorCallback = function( jqXHR, textStatus, errorThrown ) {
-			var data,
-				errorText = lang.errorText;
-
-			/*
-			 * As of 1.5.2, we are hooking into the shutdown and checking for
-			 * errors. If a fatal error is found, we will return that, rather
-			 * than the generic errorText defined above.
-			 */
-			if ( jqXHR.responseText !== undefined && '{' === jqXHR.responseText.charAt( 0 ) ) {
-				data = JSON.parse( jqXHR.responseText );
-
-				if ( data !== undefined && data.data !== undefined && data.data.errorText !== undefined ) {
-					errorText = data.data.errorText;
-				}
-			}
-
-			// Show error message.
-			markup = '<div class="notice notice-error"><p>' + errorText + '</p></div>';
-
-			$backupSiteResults.html( markup );
-		};
-
-		/**
-		 * @summary backupNow success callback.
-		 *
-		 * This is the success callback function for the boldgrid_backup_now ajax call, which is
-		 * handled by $Boldgrid_Backup_Admin_Core->boldgrid_backup_now_callback().
-		 *
-		 * @since 1.5.3
-		 */
-		successCallback = function( response ) {
-			var data = JSON.parse( response ),
-				success = data.success !== undefined && true === data.success,
-				callback =
-					success && data.data !== undefined && data.data.callback !== undefined ?
-						data.data.callback :
-						null;
-
-			$( 'body' ).trigger( 'boldgrid_backup_complete' );
-
-			switch ( callback ) {
-				case 'updateProtectionEnabled':
-					self.updateProtectionEnabled();
-					break;
-				case 'reload':
-					location.reload();
-					break;
-			}
-		};
 
 		// Generate the data array.
 		data = {
@@ -197,48 +127,41 @@ BOLDGRID.BACKUP.BackupNow = function( $ ) {
 			BOLDGRID.BACKUP.UpdateSelectors.disable();
 		}
 
-		// Make the call.
+		/*
+		 * Make the ajax call to "Backup Site Now".
+		 *
+		 * No success, error, or complete callback is passed to the ajax call. Successes will be
+		 * handled by "in progress".
+		 */
 		$.ajax( {
 			url: ajaxurl,
 			data: data,
-			type: 'post',
-			dataType: 'text',
-			success: successCallback,
-			error: errorCallback,
-			complete: function() {
-
-				// Hide the spinner.
-				$backupSiteSection.find( '.spinner' ).removeClass( 'is-active' );
-
-				if ( undefined !== BOLDGRID.BACKUP.UpdateSelectors ) {
-					BOLDGRID.BACKUP.UpdateSelectors.enable();
-				}
-			}
+			type: 'post'
 		} );
 
-		$( 'body' ).trigger( 'boldgrid_backup_initiated' );
+		/*
+		 * Take action now that the ajax call to create a backup has been triggered.
+		 *
+		 * If we're on the Backup Archive's page page, reload the page. Within the "Backup Site Now"
+		 * modal, the user will be given a notice that their backup has started, and that the page will
+		 * refresh and display a progress bar.
+		 *
+		 * Else, trigger 'boldgrid_backup_initiated'. The only listener is in-progress.js. When a
+		 * backup has been initiated, it starts the WordPress Heartbeat and shows the in progress container.
+		 */
+		if ( 'boldgrid-backup_page_boldgrid-backup' === pagenow ) {
+			setTimeout(
+				function() {
+					location.reload();
+				},
+				3000
+			);
+		} else {
+			$( 'body' ).trigger( 'boldgrid_backup_initiated' );
+		}
 
 		// Prevent default browser action.
 		e.preventDefault();
-	};
-
-	/**
-	 * @summary Show notice after backup and upgrade protection now enabled.
-	 *
-	 * This updates the current notice rather than generates a new one.
-	 *
-	 * @since 1.5.3
-	 */
-	self.updateProtectionEnabled = function() {
-		var $notice = $( '#backup-site-now-results' ).closest( '.notice' ),
-			$status = $notice.find( '#protection_enabled' ),
-			$backupNow = $( '#backup-site-now-section' );
-
-		$notice.removeClass( 'notice-warning' ).addClass( 'notice-success' );
-
-		$status.html( lang.updateProtectionActivated );
-
-		$backupNow.html( '<p>' + lang.backupCreated + '</p>' );
 	};
 };
 

--- a/admin/js/boldgrid-backup-admin-in-progress.js
+++ b/admin/js/boldgrid-backup-admin-in-progress.js
@@ -85,6 +85,11 @@ BOLDGRID.BACKUP = BOLDGRID.BACKUP || {};
 					 */
 					$( document ).on( 'boldgrid_backup_progress_notice_added', 'body', self.onInProgress );
 
+					/*
+					 * Take action when a backup is started.
+					 *
+					 * The only script triggering this event is backup-now.js.
+					 */
 					$( document ).on( 'boldgrid_backup_initiated', 'body', self.onBackupInitiated );
 
 					$( document ).on( 'boldgrid_backup_complete', 'body', self.onComplete );
@@ -142,6 +147,31 @@ BOLDGRID.BACKUP = BOLDGRID.BACKUP || {};
 			// Bail out of the heartbeat.
 			$( document ).off( 'heartbeat-tick', self.onHeartbeatTick );
 			$( document ).off( 'heartbeat-send', self.heartbeatModify );
+
+			/*
+			 * Show a notice that upgrade protection is now enabled. This updates the current notice
+			 * rather than generate a new one.
+			 *
+			 * This logic was originally introduced in 1.5.3 within backup-now.js. As of 1.12.0 it
+			 * has been moved here so that backup-now.js can focus soley on triggering the ajax call
+			 * to generate the backup and nothing else.
+			 */
+			$( '#backup-site-now-results' ).closest( '.notice' )
+				// Change it from warning to success.
+				.removeClass( 'notice-warning' ).addClass( 'notice-success' )
+				// Find the protection enabled and change the html.
+				.find( '#protection_enabled' ).html( self.i18n.update_protection_activated );
+
+			/*
+			 * When a backup is completed, replace the "Backup Site Now" button with a "Backup Created
+			 * Successfully" message.
+			 *
+			 * The .backup-site-now-section is the container for the "Backup Site Now" <form>.
+			 *
+			 * We're targeting the "visible" section so that the non-visible section, the one in the
+			 * modal, does not get overwritten.
+			 */
+			$( '#backup-site-now-section:visible' ).html( '<p>' + self.i18n.backup_created + '</p>' );
 		},
 
 		/**


### PR DESCRIPTION
This PR changes the "Backup Site Now" ajax calls. We are no longer waiting for the ajax call to finish. Instead, we are letting the "In progress" system wait for the backup to complete, and then take necessary action.

This change also refreshes the page in order to display "In progress" data when backup initiated through the modal.

----

In testing this PR, I tested the the following pages that allow a backup:
* Dashboard > Updates
* Plugins
* BoldGrid Backup > Backup Archives
* Customizer

For each of these areas, I:
1. Created a backup and ensured the page updated successfully after the backup
1. Created a backup, refreshed the page, ensured the progress bar appeared, and that the page updated successfully after the backup.

----

This commit cleans up a bit of javascript, so I did quite a bit of testing. However, another set of eyes is needed.