### PR TITLE
Log improvements

### DIFF
--- a/admin/class-boldgrid-backup-admin-log-page.php
+++ b/admin/class-boldgrid-backup-admin-log-page.php
@@ -90,7 +90,7 @@ class Boldgrid_Backup_Admin_Log_Page {
 		}
 
 		// Good to go.
-		$markup = '<div style="overflow:auto;white-space:pre;font-family:\'Courier New\';">' . esc_html( $contents ) . '</div>';
+		$markup = '<div style="overflow:auto;white-space:pre-wrap;font-family:\'Courier New\';">' . esc_html( $contents ) . '</div>';
 		wp_send_json_success( $markup );
 	}
 }

--- a/admin/class-boldgrid-backup-admin-log.php
+++ b/admin/class-boldgrid-backup-admin-log.php
@@ -188,6 +188,11 @@ class Boldgrid_Backup_Admin_Log {
 			return;
 		}
 
+		if ( ! function_exists( 'pcntl_async_signals' ) ) {
+			$this->add( 'Cannot add signal handlers, pcntl_async_signals function does not exist.' );
+			return;
+		}
+
 		// Enable asynchronous signal handling.
 		pcntl_async_signals( true );
 

--- a/admin/compressor/class-boldgrid-backup-admin-compressor-php-zip.php
+++ b/admin/compressor/class-boldgrid-backup-admin-compressor-php-zip.php
@@ -253,7 +253,13 @@ class Boldgrid_Backup_Admin_Compressor_Php_Zip extends Boldgrid_Backup_Admin_Com
 			}
 		}
 
+		$this->core->logger->add( 'Starting to close the zip file.' );
+		$this->core->logger->add_memory();
+
 		$close = $this->zip->close();
+
+		$this->core->logger->add( 'Finished closing the zip file.' );
+		$this->core->logger->add_memory();
 
 		Boldgrid_Backup_Admin_In_Progress_Data::delete_arg( 'step' );
 

--- a/admin/css/boldgrid-backup-admin.css
+++ b/admin/css/boldgrid-backup-admin.css
@@ -330,3 +330,21 @@ p > .bgbkup-remote-logo {
 	margin-left: 10px;
 	padding-left: 23px;
 }
+
+/**
+ * Misc.
+ */
+
+/* Allow the standard Thickbox to be shown full screen. */
+#TB_window.bg-full-screen {
+	margin: 0 !important;
+	top: 30px;
+	left: 30px;
+	width: calc( 100% - 60px ) !important;
+	height: calc( 100% - 60px );
+}
+
+#TB_window.bg-full-screen #TB_ajaxContent {
+	width: calc( 100% - 40px ) !important;
+	height: calc( 100% - 60px ) !important;
+}

--- a/admin/js/boldgrid-backup-admin-logs.js
+++ b/admin/js/boldgrid-backup-admin-logs.js
@@ -62,6 +62,8 @@ BOLDGRID.BACKUP = BOLDGRID.BACKUP || {};
 			 * worked. To be on the safe side, we're using 10ms.
 			 */
 			setTimeout( function() {
+				$( '#TB_window' ).addClass( 'bg-full-screen' );
+
 				$( '#TB_ajaxContent' ).html(
 					'<p id="bgbu_thickbox_loading">' +
 						self.i18n.loading +

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.12.5
+ *          Version: 1.12.6
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -138,6 +138,7 @@ Release date: ??
 
 * Update:      Open logs full screen.
 * Update:      Added additional info to the logs.
+* Update:      Logs now listen for signals, can log when a script is killed.
 
 = 1.12.5 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,13 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 
 == Changelog ==
 
+= 1.12.6 =
+
+Release date: ??
+
+* Update:      Open logs full screen.
+* Update:      Added additional info to the logs.
+
 = 1.12.5 =
 
 Release date: January 14th, 2020

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 4.4
 Tested up to: 5.3
 Requires PHP: 5.4
-Stable tag: 1.12.5
+Stable tag: 1.12.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -134,7 +134,7 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 
 = 1.12.6 =
 
-Release date: ??
+Release date: January 16th, 2020
 
 * Update:      Open logs full screen.
 * Update:      Added additional info to the logs.

--- a/tests/admin/test-class-boldgrid-backup-admin-core.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-core.php
@@ -235,6 +235,11 @@ class Test_Boldgrid_Backup_Admin_Core extends WP_UnitTestCase {
 	public function setUp() {
 		global $wpdb;
 
+		if ( ! defined( 'BOLDGRID_BACKUP_VERSION' ) ) {
+			$file = dirname( dirname( dirname( __FILE__ ) ) ) . '/boldgrid-backup.php';
+			define( 'BOLDGRID_BACKUP_VERSION', implode( get_file_data( $file, array( 'Version' ), 'plugin' ) ) );
+		}
+
 		$this->core = apply_filters( 'boldgrid_backup_get_core', null );
 
 		$this->zip = new Boldgrid_Backup_Admin_Compressor_Pcl_Zip( $this->core );


### PR DESCRIPTION
Logs should open full screen.

If a backup is killed, `kill pid`, it should show in the logs.

![image](https://user-images.githubusercontent.com/5925563/72548489-c9ae2000-385c-11ea-987a-556ddeb7619e.png)
