### PR TITLE
changed access to method move_backups from private to public

### DIFF
--- a/admin/class-boldgrid-backup-admin-settings.php
+++ b/admin/class-boldgrid-backup-admin-settings.php
@@ -402,7 +402,7 @@ class Boldgrid_Backup_Admin_Settings {
 	 * @param string $new_dir Destination directory.
 	 * @return bool TRUE on success / no backups needed to be moved.
 	 */
-	private function move_backups( $old_dir, $new_dir ) {
+	public function move_backups( $old_dir, $new_dir ) {
 		$fail_count = 0;
 
 		$old_dir = Boldgrid_Backup_Admin_Utility::trailingslashit( $old_dir );


### PR DESCRIPTION
This change is to close issue [https://github.com/BoldGrid/boldgrid-backup/issues/213](https://github.com/BoldGrid/boldgrid-backup/issues/213) which caused a fatal error when trying to move backups from one directory to another