### PR TITLE
reverted installer to default configuration

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -46,9 +46,9 @@ install_test_suite() {
 
 	# phpunit tests temporarily changed from "trunk" to "5.2". They should be reverted after a resolution
 	# is found here: https://core.trac.wordpress.org/ticket/49377#ticket
-	svn co --quiet https://develop.svn.wordpress.org/branches/5.2/tests/phpunit/includes/
-
-	wget -nv -O wp-tests-config.php https://develop.svn.wordpress.org/branches/5.2/wp-tests-config-sample.php
+	svn co --quiet https://develop.svn.wordpress.org/trunk/tests/phpunit/includes/
+	
+	wget -nv -O wp-tests-config.php https://develop.svn.wordpress.org/trunk/wp-tests-config-sample.php
 	sed $ioption "s:dirname( __FILE__ ) . '/build/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
 	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php

--- a/composer.lock
+++ b/composer.lock
@@ -1,23 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "00f1abd158c93ffde8b00cf13e347927",
     "packages": [
         {
             "name": "boldgrid/library",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BoldGrid/library.git",
-                "reference": "02d8f828136ba6df876c1d5ddaf3d1e7309765a9"
+                "reference": "3c8169f6946008b68cd567bcfacd42f188272525"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BoldGrid/library/zipball/02d8f828136ba6df876c1d5ddaf3d1e7309765a9",
-                "reference": "02d8f828136ba6df876c1d5ddaf3d1e7309765a9",
+                "url": "https://api.github.com/repos/BoldGrid/library/zipball/3c8169f6946008b68cd567bcfacd42f188272525",
+                "reference": "3c8169f6946008b68cd567bcfacd42f188272525",
                 "shasum": ""
             },
             "type": "library",
@@ -54,7 +54,7 @@
                 }
             ],
             "description": "The BoldGrid Library for shared code used in official BoldGrid plugins and themes.",
-            "time": "2020-02-06T17:29:29+00:00"
+            "time": "2020-02-07T18:48:57+00:00"
         },
         {
             "name": "chland/tdcron",


### PR DESCRIPTION
The installer was changed due to a bug in wordpress's updated tests. This has been resolved, so the installer has been reverted to it's state as it was before the bug.