### PR TITLE
Issue 283

### DIFF
--- a/admin/class-boldgrid-backup-admin-support.php
+++ b/admin/class-boldgrid-backup-admin-support.php
@@ -48,13 +48,17 @@ class Boldgrid_Backup_Admin_Support {
 	}
 
 	/**
-	 * Deactivate and show an error.
+	 * Add an admin notice.
+	 *
+	 * This method use to be "deactivate". Users only have 1 chance to see the message we're showing
+	 * if we deactivate the plugin. If we instead just show an admin message, the user has more than
+	 * once chance to see the notice and take action to resolve the issue.
 	 *
 	 * @since 1.7.0
 	 *
 	 * @param string $error Error message.
 	 */
-	public function deactivate( $error ) {
+	public function add_admin_notice( $error ) {
 		add_action(
 			'admin_notices', function () use ( $error ) {
 				$allowed_html = [
@@ -62,15 +66,32 @@ class Boldgrid_Backup_Admin_Support {
 					'strong' => [],
 					'br'     => [],
 					'em'     => [],
+					'pre'    => [],
+					'a'      => [
+						'href'   => [],
+						'target' => [],
+					],
 				];
 
 				$error = '<p>' . sprintf(
 					// translators: 1: HTML opening strong tags, 2: HTML closing strong tag, 3: Plugin title.
-					__( '%1$s%3$s%2$s has been deactivated due to the following error:', 'boldgrid-backup' ),
+					__( '%1$s%3$s%2$s is unable to load due to the following error:', 'boldgrid-backup' ),
 					'<strong>',
 					'</strong>',
 					BOLDGRID_BACKUP_TITLE
 				) . '<br /><br />' . $error . '</p>';
+
+				// Inform the user how to get help.
+				$error .= '<p>' . sprintf(
+					// translators: 1 Plugin title, 2 opening anchor tag linking to plugin page, 3 url to plugin page, 4 closing anchor tag.
+					__( 'Please deactivate / reactivate Total Upkeep as this often resolves issues. If you are installing %1$s from .zip, ensure you downloaded it from %2$s%3$s%4$s. For additional help, please post a question in the %5$sWordPress Support Forums.%4$s', 'boldgrid-backup' ),
+					BOLDGRID_BACKUP_TITLE,
+					'<a href="https://wordpress.org/plugins/boldgrid-backup/" target="_blank">',
+					'https://wordpress.org/plugins/boldgrid-backup/',
+					'</a>',
+					'<a href="https://wordpress.org/support/plugin/boldgrid-backup/#new-topic-0" target="_blank">'
+				) . '</p>';
+
 
 				// Echo our admin notice. Hide the "plugin activated" notice.
 				echo '
@@ -79,12 +100,6 @@ class Boldgrid_Backup_Admin_Support {
 					.updated.notice { display: none; }
 				</style>
 			';
-			}
-		);
-
-		add_action(
-			'admin_init', function() {
-				deactivate_plugins( 'boldgrid-backup/boldgrid-backup.php', true );
 			}
 		);
 	}
@@ -115,6 +130,21 @@ class Boldgrid_Backup_Admin_Support {
 	}
 
 	/**
+	 * Verify appropriate library is available.
+	 *
+	 * This is a very basic test. It could be more exhaustive. However, a missing library is rare and
+	 * exhaustive tests are not needed.
+	 *
+	 * @since 1.13.5
+	 *
+	 * @return bool
+	 */
+	public function has_library() {
+		// This can be updated to the newest library classes to check for a more recent version.
+		return class_exists( 'Boldgrid\Library\Library\Usage\Notice' );
+	}
+
+	/**
 	 * Whether or not this version of the Backup Plugin is compatible with the premium extension.
 	 *
 	 * @since 1.11.3
@@ -129,6 +159,9 @@ class Boldgrid_Backup_Admin_Support {
 	/**
 	 * Run tests.
 	 *
+	 * These tests are triggered by the main class-boldgrid-backup.php file. If these tests fail, the
+	 * rest of the plugin will not load.
+	 *
 	 * @since 1.7.1
 	 *
 	 * @see has_compatible_php()
@@ -138,8 +171,13 @@ class Boldgrid_Backup_Admin_Support {
 	 * @return bool
 	 */
 	public function run_tests() {
+		// Utility method required in this method.
+		if ( ! class_exists( 'Boldgrid_Backup_Admin_Utility' ) ) {
+			require_once BOLDGRID_BACKUP_PATH . '/admin/class-boldgrid-backup-admin-utility.php';
+		}
+
 		if ( ! $this->has_compatible_php() ) {
-			$this->deactivate(
+			$this->add_admin_notice(
 				sprintf(
 					// Translators: 1: Current PHP version, 2: Minimum supported PHP version.
 					__(
@@ -155,12 +193,35 @@ class Boldgrid_Backup_Admin_Support {
 		}
 
 		if ( ! $this->has_composer_installed() ) {
-			$this->deactivate(
+			$this->add_admin_notice(
 				__(
 					'The vendor folder is missing. Please run "composer install", or contact your host for further assistance.',
 					'boldgrid-backup'
 				)
 			);
+
+			return false;
+		}
+
+		/*
+		 * Do a basic test and ensure we have access to the library.
+		 *
+		 * In theory, we should never have an issue with the library loading. This method should never
+		 * be needed, and any issues with the library should be troubleshooted and resolved. However,
+		 * we cannot have a library issue cause a fatal error, hence this check.
+		 *
+		 * Total Upkeep's library is only registered after activation, hence the is_active() check below.
+		 */
+		if ( Boldgrid_Backup_Admin_Utility::is_active() && ! $this->has_library() ) {
+			$boldgrid_settings = get_option( 'boldgrid_settings', array() );
+
+			$this->add_admin_notice( sprintf(
+				__(
+					'One or more library files are missing. Registered libraries: %1$s',
+					'boldgrid-backup'
+				),
+				! empty( $boldgrid_settings['library'] ) ? '<pre>' . print_r( $boldgrid_settings['library'], 1 ) . '</pre>' : __( 'None', 'boldgrid-backup' )
+			));
 
 			return false;
 		}

--- a/admin/class-boldgrid-backup-admin-support.php
+++ b/admin/class-boldgrid-backup-admin-support.php
@@ -176,9 +176,9 @@ class Boldgrid_Backup_Admin_Support {
 				__(
 					'One or more library files are missing. Registered libraries: %1$s',
 					'boldgrid-backup'
-					),
+				),
 				! empty( $boldgrid_settings['library'] ) ? '<pre>' . print_r( $boldgrid_settings['library'], 1 ) . '</pre>' : __( 'None', 'boldgrid-backup' ) // phpcs:ignore
-				));
+			));
 
 			return false;
 		}

--- a/admin/class-boldgrid-backup-admin-support.php
+++ b/admin/class-boldgrid-backup-admin-support.php
@@ -156,6 +156,37 @@ class Boldgrid_Backup_Admin_Support {
 	}
 
 	/**
+	 * Do a basic test and ensure we have access to the library.
+	 *
+	 * In theory, we should never have an issue with the library loading. This method should never
+	 * be needed, and any issues with the library should be troubleshooted and resolved. However,
+	 * we cannot have a library issue cause a fatal error, hence this check.
+	 *
+	 * @since 1.13.5
+	 *
+	 * @return bool
+	 */
+	public function run_library_tests() {
+		// Total Upkeep's library is only registered after activation, hence the is_active() check below.
+		if ( Boldgrid_Backup_Admin_Utility::is_active() && ! $this->has_library() ) {
+			$boldgrid_settings = get_option( 'boldgrid_settings', array() );
+
+			$this->add_admin_notice( sprintf(
+				// translators: 1 A list of library versions that are registered. It will be within a <pre> tag.
+				__(
+					'One or more library files are missing. Registered libraries: %1$s',
+					'boldgrid-backup'
+					),
+				! empty( $boldgrid_settings['library'] ) ? '<pre>' . print_r( $boldgrid_settings['library'], 1 ) . '</pre>' : __( 'None', 'boldgrid-backup' ) // phpcs:ignore
+				));
+
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Run tests.
 	 *
 	 * These tests are triggered by the main class-boldgrid-backup.php file. If these tests fail, the
@@ -198,30 +229,6 @@ class Boldgrid_Backup_Admin_Support {
 					'boldgrid-backup'
 				)
 			);
-
-			return false;
-		}
-
-		/*
-		 * Do a basic test and ensure we have access to the library.
-		 *
-		 * In theory, we should never have an issue with the library loading. This method should never
-		 * be needed, and any issues with the library should be troubleshooted and resolved. However,
-		 * we cannot have a library issue cause a fatal error, hence this check.
-		 *
-		 * Total Upkeep's library is only registered after activation, hence the is_active() check below.
-		 */
-		if ( Boldgrid_Backup_Admin_Utility::is_active() && ! $this->has_library() ) {
-			$boldgrid_settings = get_option( 'boldgrid_settings', array() );
-
-			$this->add_admin_notice( sprintf(
-				// translators: 1 A list of library versions that are registered. It will be within a <pre> tag.
-				__(
-					'One or more library files are missing. Registered libraries: %1$s',
-					'boldgrid-backup'
-				),
-				! empty( $boldgrid_settings['library'] ) ? '<pre>' . print_r( $boldgrid_settings['library'], 1 ) . '</pre>' : __( 'None', 'boldgrid-backup' ) // phpcs:ignore
-			));
 
 			return false;
 		}

--- a/admin/class-boldgrid-backup-admin-support.php
+++ b/admin/class-boldgrid-backup-admin-support.php
@@ -92,7 +92,6 @@ class Boldgrid_Backup_Admin_Support {
 					'<a href="https://wordpress.org/support/plugin/boldgrid-backup/#new-topic-0" target="_blank">'
 				) . '</p>';
 
-
 				// Echo our admin notice. Hide the "plugin activated" notice.
 				echo '
 				<div class="notice notice-error is-dismissible">' . wp_kses( $error, $allowed_html ) . '</div>
@@ -216,11 +215,12 @@ class Boldgrid_Backup_Admin_Support {
 			$boldgrid_settings = get_option( 'boldgrid_settings', array() );
 
 			$this->add_admin_notice( sprintf(
+				// translators: 1 A list of library versions that are registered. It will be within a <pre> tag.
 				__(
 					'One or more library files are missing. Registered libraries: %1$s',
 					'boldgrid-backup'
 				),
-				! empty( $boldgrid_settings['library'] ) ? '<pre>' . print_r( $boldgrid_settings['library'], 1 ) . '</pre>' : __( 'None', 'boldgrid-backup' )
+				! empty( $boldgrid_settings['library'] ) ? '<pre>' . print_r( $boldgrid_settings['library'], 1 ) . '</pre>' : __( 'None', 'boldgrid-backup' ) // phpcs:ignore
 			));
 
 			return false;

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -497,6 +497,26 @@ class Boldgrid_Backup_Admin_Utility {
 	}
 
 	/**
+	 * Determine whether or not Total Upkeep is active.
+	 *
+	 * The fact that Total Upkeep is calling this method shows that it is installed and activated.
+	 * However, it we are not listed in the "active_plugins" option, then we are in the middle of
+	 * activation.
+	 *
+	 * Because the library may not be available until activation, this method can help us determine
+	 * whether or not we should instantiate library classes at a certain time.
+	 *
+	 * @since 1.13.5
+	 *
+	 * @return bool
+	 */
+	public static function is_active() {
+		$active_plugins = get_option( 'active_plugins', array() );
+
+		return in_array( 'boldgrid-backup/boldgrid-backup.php', $active_plugins, true );
+	}
+
+	/**
 	 * Determine whether or not the given $page is the current.
 	 *
 	 * @since 1.7.0

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -118,6 +118,11 @@ function load_boldgrid_backup() {
 		)
 	);
 
+	// Make sure we have necessary library files.
+	if ( ! $support->run_library_tests() ) {
+		return false;
+	}
+
 	register_activation_hook( __FILE__, 'activate_boldgrid_backup' );
 	register_deactivation_hook( __FILE__, 'deactivate_boldgrid_backup' );
 


### PR DESCRIPTION
(1) Look at #283 and (2) read the comments in the code for an explanation of this PR. It should be self explanatory.

You can cause a bug by renaming `vendor/boldgrid/library/src/Library/Usage/Notice.php` to `vendor/boldgrid/library/src/Library/Usage/Votice.php`.

Basically, the goal is to prevent fatal errors.