### PR TITLE
Update class-boldgrid-backup-admin-notice.php

### DIFF
--- a/admin/class-boldgrid-backup-admin-notice.php
+++ b/admin/class-boldgrid-backup-admin-notice.php
@@ -240,7 +240,7 @@ class Boldgrid_Backup_Admin_Notice {
 			( apply_filters( 'allow_major_auto_core_updates', false ) ) ? 'Major' : false,
 			( apply_filters( 'allow_minor_auto_core_updates', false ) ) ? 'Minor' : false,
 			( apply_filters( 'allow_dev_auto_core_updates', false ) ) ? 'Development' : false,
-			( apply_filters( 'auto_update_translation', false ) ) ? 'Translation' : false,
+			( apply_filters( 'auto_update_translation', false, wp_get_translation_updates() ) ) ? 'Translation' : false,
 		];
 		$auto_update_array = array_filter( $auto_update_array );
 		$update_msg        = '';

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.14.0
+ *          Version: 1.14.1
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 4.4
 Tested up to: 5.4
 Requires PHP: 5.4
-Stable tag: 1.14.0
+Stable tag: 1.14.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -131,6 +131,12 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 1. Activate the plugin through the Plugins menu in WordPress.
 
 == Changelog ==
+
+= 1.14.1 =
+
+Release date: July 7th, 2020
+
+* Bug fix: Auto Update Translation filter causes fatal error with JetPack active [#50]((https://github.com/BoldGrid/boldgrid-backup-premium/issues/50)
 
 = 1.14.0 =
 


### PR DESCRIPTION
This patch is related to a issue [#50](https://github.com/BoldGrid/boldgrid-backup-premium/issues/50) in boldgrid-backup-premium, where the incorrect number of arguments for the 'auto_update_translation' filter was causing errors with Jetpack. This patch should proactively prevent this from occuring in the free version of the plugin.