### PR TITLE
Add additional library checks. Fixes #367

### DIFF
--- a/admin/class-boldgrid-backup-admin-support.php
+++ b/admin/class-boldgrid-backup-admin-support.php
@@ -154,6 +154,17 @@ class Boldgrid_Backup_Admin_Support {
 			}
 		}
 
+		$methods = array(
+			'Boldgrid\Library\Library\Plugin\Plugins' => 'getAllPlugins',
+		);
+
+		foreach ( $methods as $class => $method ) {
+			if ( ! method_exists( $class, $method ) ) {
+				$has_library = false;
+				break;
+			}
+		}
+
 		return $has_library;
 	}
 


### PR DESCRIPTION
To test... Please review #367. Then, rename that `getAllPlugins` class to something else so it doesn't exist. Then, test the plugin. You should get a message instead of a fatal error.