### PR TITLE
added fix for newly installed plugins / themes

### DIFF
--- a/admin/class-boldgrid-backup-admin-auto-updates.php
+++ b/admin/class-boldgrid-backup-admin-auto-updates.php
@@ -105,6 +105,20 @@ class Boldgrid_Backup_Admin_Auto_Updates {
 			$settings['auto_update'][ $update_type ][ $offer ] = in_array( $offer, $enabled_offers, true ) ? '1' : '0';
 		}
 
+		/*
+		 * The above loop cannot account for the presence of a plugin or theme in the $enabled_offers
+		 * array, that does not yet exist in the auto update settings. This will be the case if a new plugin or theme is installed
+		 * before they settings for that theme or plugin have been set in the Total Upkeep settings page. This will ensure that
+		 * scenario is covered.
+		 */
+		foreach ( $enabled_offers as $enabled_offer ) {
+			if ( isset( $settings['auto_update'][ $update_type ][ $enabled_offer ] ) ) {
+				continue;
+			} else {
+				$settings['auto_update'][ $update_type ][ $enabled_offer ] = '1';
+			}
+		}
+
 		// Save the settings.
 		$core->settings->save( $settings );
 	}

--- a/admin/class-boldgrid-backup-admin-auto-updates.php
+++ b/admin/class-boldgrid-backup-admin-auto-updates.php
@@ -112,11 +112,7 @@ class Boldgrid_Backup_Admin_Auto_Updates {
 		 * scenario is covered.
 		 */
 		foreach ( $enabled_offers as $enabled_offer ) {
-			if ( isset( $settings['auto_update'][ $update_type ][ $enabled_offer ] ) ) {
-				continue;
-			} else {
-				$settings['auto_update'][ $update_type ][ $enabled_offer ] = '1';
-			}
+			$settings['auto_update'][ $update_type ][ $enabled_offer ] = '1';
 		}
 
 		// Save the settings.

--- a/readme.txt
+++ b/readme.txt
@@ -134,7 +134,7 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 
 = 1.14.3 =
 
-Release date: August 12th, 2020
+Release date: August 13th, 2020
 
 * Update: Updated Auto Update features to utilize the WordPress 5.5+ Auto Update UI.
 


### PR DESCRIPTION
If you install a new plugin or new theme and change the settings using WP Auto Update UI, the changes do not take effect in boldgrid backup settings because the plugin / theme does not already exist in those settings. This update addresses that issue.