### PR TITLE
Update "I already did" verbiage

### DIFF
--- a/includes/config/config.rating-prompt.php
+++ b/includes/config/config.rating-prompt.php
@@ -68,7 +68,7 @@ $default_prompt = [
 					'slide'  => 'maybe_later',
 				],
 				'already_did'         => [
-					'text'  => esc_html__( 'I already did', 'boldgrid-backup' ),
+					'text'  => esc_html__( 'I already did / Permanently dismiss this notice', 'boldgrid-backup' ),
 					'slide' => 'already_did',
 				],
 			],


### PR DESCRIPTION
Several users have mentioned the option to dismiss is hard to find (unclear how to dismiss) - such as https://wordpress.org/support/topic/great-product-annoyance-begging-for-review/