### PR TITLE
Exclude archive file extensions

### DIFF
--- a/admin/class-boldgrid-backup-admin-folder-exclusion.php
+++ b/admin/class-boldgrid-backup-admin-folder-exclusion.php
@@ -26,7 +26,7 @@ class Boldgrid_Backup_Admin_Folder_Exclusion {
 	 * @since 1.6.0
 	 * @var   string
 	 */
-	public $default_exclude = '.git,node_modules,*.zip,*.gz,*.tar,*wpress,*.tmp';
+	public $default_exclude = '.git,node_modules,*.zip,*.gz,*.tar,*.wpress,*.tmp';
 
 	/**
 	 * The default include value.

--- a/admin/class-boldgrid-backup-admin-folder-exclusion.php
+++ b/admin/class-boldgrid-backup-admin-folder-exclusion.php
@@ -26,7 +26,7 @@ class Boldgrid_Backup_Admin_Folder_Exclusion {
 	 * @since 1.6.0
 	 * @var   string
 	 */
-	public $default_exclude = '.git,node_modules';
+	public $default_exclude = '.git,node_modules,*.zip,*.gz,*.tar,*wpress,*.tmp';
 
 	/**
 	 * The default include value.


### PR DESCRIPTION
addresses issue #234.

there's probably a different way to exclude these file types automatically, but using this construction has the benefit of giving users the ability to change the configuration if they decide that they want to include archive files in their backups.