### PR TITLE
Rest change url

### DIFF
--- a/admin/class-boldgrid-backup-admin-core.php
+++ b/admin/class-boldgrid-backup-admin-core.php
@@ -1340,7 +1340,10 @@ class Boldgrid_Backup_Admin_Core {
 		// If changed, then update the siteurl in the database.
 		if ( $restored_wp_siteurl !== $wp_siteurl ) {
 			$update_siteurl_success =
-				Boldgrid_Backup_Admin_Utility::update_siteurl( $restored_wp_siteurl, $wp_siteurl );
+				Boldgrid_Backup_Admin_Utility::update_siteurl( array(
+					'old_siteurl' => $restored_wp_siteurl,
+					'siteurl'     => $wp_siteurl,
+				) );
 
 			if ( ! $update_siteurl_success ) {
 				// Display an error notice.

--- a/admin/class-boldgrid-backup-admin-restore-helper.php
+++ b/admin/class-boldgrid-backup-admin-restore-helper.php
@@ -92,7 +92,7 @@ class Boldgrid_Backup_Admin_Restore_Helper {
 	 * @since 1.5.1
 	 */
 	public function post_restore_htaccess() {
-		add_action( 'shutdown', 'flush_rewrite_rules' );
+		add_action( 'shutdown', '\Boldgrid_Backup_Admin_Utility::flush_rewrite_rules' );
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -112,15 +112,15 @@ class Boldgrid_Backup_Admin_Utility {
 
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE `' . $wpdb->prefix . '%1$s` SET `%2$s` = REPLACE( `%3$s`, \'%4$s\', \'%5$s\' ) WHERE `%6$s` LIKE \'%%%7$s%%\';',
+				'UPDATE `%1$s` SET `%2$s` = REPLACE( `%3$s`, \'%4$s\', \'%5$s\' ) WHERE `%6$s` LIKE %7$s;',
 				array(
-					$table,
+					$wpdb->prefix . $table,
 					$column,
 					$column,
 					$find,
 					$replace,
 					$column,
-					$find,
+					'%' . $wpdb->esc_like( $find ) . '%',
 				)
 			)
 		);
@@ -370,7 +370,10 @@ class Boldgrid_Backup_Admin_Utility {
 		global $wpdb;
 
 		$matched_options = $wpdb->get_results(
-			$wpdb->prepare( 'SELECT `option_name` FROM `' . $wpdb->prefix . 'options` WHERE `option_value` LIKE \'%%%1$s%%\';', $find ),
+			$wpdb->prepare(
+				'SELECT `option_name` FROM `' . $wpdb->prefix . 'options` WHERE `option_value` LIKE %1$s;',
+				'%' . $wpdb->esc_like( $find ) . '%'
+			),
 			ARRAY_N
 		);
 
@@ -818,11 +821,11 @@ class Boldgrid_Backup_Admin_Utility {
 	 * @static
 	 *
 	 * @param array $args {
-	 * 		An array of arguments.
+	 *      An array of arguments.
 	 *
-	 * 		@type string $old_siteurl The old/restored siteurl to find and be replaced.
-	 * 		@type string $siteurl     The siteurl to replace the old siteurl.
-	 * 		@type bool   $flush       Whether or not to flush the rewrite rules.
+	 *      @type string $old_siteurl The old/restored siteurl to find and be replaced.
+	 *      @type string $siteurl     The siteurl to replace the old siteurl.
+	 *      @type bool   $flush       Whether or not to flush the rewrite rules.
 	 * }
 	 * @return bool
 	 */

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -110,20 +110,22 @@ class Boldgrid_Backup_Admin_Utility {
 	public static function db_find_replace( $table, $column, $find, $replace ) {
 		global $wpdb;
 
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder, WordPress.DB.PreparedSQLPlaceholders.LikeWildcardsInQuery
 		$wpdb->query(
 			$wpdb->prepare(
-				'UPDATE `%1$s` SET `%2$s` = REPLACE( `%3$s`, \'%4$s\', \'%5$s\' ) WHERE `%6$s` LIKE %7$s;',
-				array(
-					$wpdb->prefix . $table,
-					$column,
-					$column,
-					$find,
-					$replace,
-					$column,
-					'%' . $wpdb->esc_like( $find ) . '%',
-				)
+				'UPDATE	`' . $wpdb->prefix . '%1$s`
+				SET		`%2$s` = REPLACE( `%3$s`, "%4$s", "%5$s" )
+				WHERE	`%6$s` LIKE "%%%7$s%%";',
+				$table,
+				$column,
+				$column,
+				$find,
+				$replace,
+				$column,
+				$wpdb->esc_like( $find )
 			)
 		);
+		// phpcs:enable
 	}
 
 	/**
@@ -371,7 +373,9 @@ class Boldgrid_Backup_Admin_Utility {
 
 		$matched_options = $wpdb->get_results(
 			$wpdb->prepare(
-				'SELECT `option_name` FROM `' . $wpdb->prefix . 'options` WHERE `option_value` LIKE %1$s;',
+				'SELECT	`option_name`
+				FROM	`' . $wpdb->prefix . 'options`
+				WHERE	`option_value` LIKE %s;',
 				'%' . $wpdb->esc_like( $find ) . '%'
 			),
 			ARRAY_N

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -95,6 +95,38 @@ class Boldgrid_Backup_Admin_Utility {
 	}
 
 	/**
+	 * Database find and replace.
+	 *
+	 * Take note we also have self::option_find_replace that does a find and replace specific to option
+	 * values because they are serialized. It uses self::str_replace_recursive.
+	 *
+	 * @since SINCEVERSION
+	 *
+	 * @param string $table
+	 * @param string $column
+	 * @param string $find
+	 * @param string $replace
+	 */
+	public static function db_find_replace( $table, $column, $find, $replace ) {
+		global $wpdb;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'UPDATE `' . $wpdb->prefix . '%1$s` SET `%2$s` = REPLACE( `%3$s`, \'%4$s\', \'%5$s\' ) WHERE `%6$s` LIKE \'%%%7$s%%\';',
+				array(
+					$table,
+					$column,
+					$column,
+					$find,
+					$replace,
+					$column,
+					$find,
+				)
+			)
+		);
+	}
+
+	/**
 	 * Custom error handler.
 	 *
 	 * Catches everything (including warnings) and throws an excpetion.
@@ -321,6 +353,37 @@ class Boldgrid_Backup_Admin_Utility {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Find and replace for option values.
+	 *
+	 * Similar to self::db_find_replace. This one is special however because it ends up using
+	 * self::str_replace_recursive for the replacement mechanism.
+	 *
+	 * @since SINCEVERSION
+	 *
+	 * @param string $find
+	 * @param string $replace
+	 */
+	public static function option_find_replace( $find, $replace ) {
+		global $wpdb;
+
+		$matched_options = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT `option_name` FROM `' . $wpdb->prefix . 'options` WHERE `option_value` LIKE \'%%%1$s%%\';', $find ),
+			ARRAY_N
+		);
+
+		if ( empty( $matched_options ) ) {
+			return;
+		}
+
+		foreach ( $matched_options as $option_name ) {
+			$option_value = get_option( $option_name[0] );
+			$option_value = self::str_replace_recursive( $find, $replace, $option_value );
+
+			update_option( $option_name[0], $option_value );
+		}
 	}
 
 	/**
@@ -724,6 +787,27 @@ class Boldgrid_Backup_Admin_Utility {
 	}
 
 	/**
+	 * A wrapper for WordPress' flush_rewrite_rules.
+	 *
+	 * Wrapper function is necessary because rewriting the .htaccess only works if the
+	 * save_mod_rewrite_rules() function exists, which only does in admin. This method ensures it's
+	 * there.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/51805
+	 *
+	 * @param bool $hard Whether to update .htaccess (hard flush) or just update rewrite_rules option
+	 *                   (soft flush).
+	 */
+	public static function flush_rewrite_rules( $hard = true ) {
+		// A requirement for rewriting the .htaccess file.
+		if ( $hard && ! function_exists( 'save_mod_rewrite_rules' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/misc.php';
+		}
+
+		flush_rewrite_rules( $hard );
+	}
+
+	/**
 	 * Replace the siteurl in the WordPress database.
 	 *
 	 * @since 1.2.3
@@ -733,103 +817,81 @@ class Boldgrid_Backup_Admin_Utility {
 	 *
 	 * @static
 	 *
-	 * @param string $old_siteurl The old/restored siteurl to find and be replaced.
-	 * @param string $new_siteurl The siteurl to replace the old siteurl.
+	 * @param array $args {
+	 * 		An array of arguments.
+	 *
+	 * 		@type string $old_siteurl The old/restored siteurl to find and be replaced.
+	 * 		@type string $siteurl     The siteurl to replace the old siteurl.
+	 * 		@type bool   $flush       Whether or not to flush the rewrite rules.
+	 * }
 	 * @return bool
 	 */
-	public static function update_siteurl( $old_siteurl, $new_siteurl ) {
-		// Define filter options.
-		$filter_options = FILTER_FLAG_SCHEME_REQUIRED | FILTER_FLAG_HOST_REQUIRED;
+	public static function update_siteurl( $args = array() ) {
+		wp_parse_args( $args, array(
+			'flush' => false,
+		) );
 
-		// Validate the old siteurl.
-		if ( false === filter_var( $old_siteurl, FILTER_VALIDATE_URL, $filter_options ) ) {
+		$old_siteurl = $args['old_siteurl'];
+		$new_siteurl = $args['siteurl'];
+
+		// Validate our urls and get them ready.
+		if ( false === filter_var( $old_siteurl, FILTER_VALIDATE_URL ) ) {
 			return false;
 		}
-
-		// Validate the new siteurl.
-		if ( false === filter_var( $new_siteurl, FILTER_VALIDATE_URL, $filter_options ) ) {
+		if ( false === filter_var( $new_siteurl, FILTER_VALIDATE_URL ) ) {
 			return false;
 		}
-
-		// Ensure there are no trailing slashes in siteurl.
 		$old_siteurl = untrailingslashit( $old_siteurl );
 		$new_siteurl = untrailingslashit( $new_siteurl );
 
-		// There may be a filter, so remove it.
 		remove_all_filters( 'pre_update_option_siteurl' );
 
-		// Update the WP otion "siteurl".
 		update_option( 'siteurl', $new_siteurl );
 
-		// Connect to the WordPress database via $wpdb.
-		global $wpdb;
-
-		// Get the database prefix (blog id 1 or 0 gets the base prefix).
-		$db_prefix = $wpdb->get_blog_prefix( 1 );
-
-		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders
-
-		// Replace the URL in wp_posts.
-		$wpdb->query(
-			$wpdb->prepare(
-				'UPDATE `%1$sposts` SET `post_content` = REPLACE( `post_content`, \'%2$s\', \'%3$s\' ) WHERE `post_content` LIKE \'%%%2$s%%\';',
-				array(
-					$db_prefix,
-					$old_siteurl,
-					$new_siteurl,
-				)
-			)
+		$replacers = array(
+			// Post content.
+			array(
+				'table'   => 'posts',
+				'column'  => 'post_content',
+				'find'    => $old_siteurl,
+				'replace' => $new_siteurl,
+			),
+			// Custom urls in menus.
+			array(
+				'table'   => 'postmeta',
+				'column'  => 'meta_value',
+				'find'    => $old_siteurl,
+				'replace' => $new_siteurl,
+			),
 		);
+
+		foreach ( $replacers as $replacer ) {
+			self::db_find_replace( $replacer['table'], $replacer['column'], $replacer['find'], $replacer['replace'] );
+		}
 
 		// Check if the upload_url_path needs to be updated.
 		$upload_url_path = get_option( 'upload_url_path' );
-
 		if ( ! empty( $upload_url_path ) ) {
 			$upload_url_path = str_replace( $old_siteurl, $new_siteurl, $upload_url_path );
-
 			update_option( 'upload_url_path', $upload_url_path );
 		}
 
-		// Find old siteurl references in WP options.
-		// Match old_siteurl with and without escaped URL, for example, JSON data escapes slashes.
-		$matched_options = $wpdb->get_results(
-			$wpdb->prepare(
-				'SELECT `option_name` FROM `%1$soptions` WHERE `option_value` LIKE \'%%%2$s%%\' OR `option_value` LIKE \'%%%3$s%%\';',
-				array(
-					$db_prefix,
-					$old_siteurl,
-					addslashes( $old_siteurl ),
-				)
-			),
-			ARRAY_N
-		);
+		// Find and replace option values.
+		self::option_find_replace( addslashes( $old_siteurl ), addslashes( $new_siteurl ) );
+		self::option_find_replace( $old_siteurl, $new_siteurl );
 
-		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders
-
-		// If there are no matches options, then return.
-		if ( ! $matched_options ) {
-			return true;
-		}
-
-		// Replace the siteurl in matched options.
-		foreach ( $matched_options as $option_name ) {
-			$option_value = get_option( $option_name[0] );
-
-			// Replace siteurl.
-			$option_value = self::str_replace_recursive(
-				$old_siteurl,
-				$new_siteurl,
-				$option_value
-			);
-
-			// Replace siteurl escaped with slashes.
-			$option_value = self::str_replace_recursive(
-				addslashes( $old_siteurl ),
-				addslashes( $new_siteurl ),
-				$option_value
-			);
-
-			update_option( $option_name[0], $option_value );
+		/*
+		 * If requested (false by default), flush the rewrite rules.
+		 *
+		 * Why not make this a standard operation? We would except for the fact that the
+		 * Boldgrid_Backup_Admin_Restore_Helper class adds the "flush_rewrite_rules" function to the
+		 * "shutdown" hook. Does it need to be done at shutdown? Not entirely sure.
+		 *
+		 * This optional action is helpful when updating the site url outside of a restoration process,
+		 * IE a stand alone REST call to update the site url.
+		 */
+		if ( ! empty( $args['flush'] ) ) {
+			self::flush_rewrite_rules();
 		}
 
 		return true;

--- a/includes/class-boldgrid-backup.php
+++ b/includes/class-boldgrid-backup.php
@@ -300,6 +300,7 @@ class Boldgrid_Backup {
 		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-setting.php';
 		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-archive.php';
 		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-test.php';
+		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-siteurl.php';
 
 		require_once BOLDGRID_BACKUP_PATH . '/admin/class-boldgrid-backup-admin-usage.php';
 
@@ -587,6 +588,9 @@ class Boldgrid_Backup {
 
 			$rest_test = new Boldgrid_Backup_Rest_Test( $plugin_admin_core );
 			$rest_test->register_routes();
+
+			$rest_siteurl = new Boldgrid_Backup_Rest_Siteurl( $plugin_admin_core );
+			$rest_siteurl->register_routes();
 		} );
 
 		$usage = new Boldgrid_Backup_Admin_Usage();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,4 +21,7 @@
 			<group>ajax</group>
 		</exclude>
 	</groups>
+	<php>
+		 <ini name="display_errors" value="true"/>
+	</php>
 </phpunit>

--- a/rest/README.MD
+++ b/rest/README.MD
@@ -109,3 +109,33 @@ jQuery.ajax({
 	type: 'put'
 });
 ```
+
+## Site URL ##
+
+### Get ###
+
+```
+jQuery.ajax( {
+    url: jQuery( '#bgbkup_site_url' ).val()  + '/wp-json/bgbkup/v1/siteurl',
+    method: 'GET',
+    beforeSend: function ( xhr ) {
+        xhr.setRequestHeader( 'X-WP-Nonce', jQuery( '#wp_rest' ).val() );
+    }
+} ).done( function ( response ) {
+    console.log( response );
+} );
+```
+
+### Set ###
+
+```
+jQuery.ajax( {
+    url: jQuery( '#bgbkup_site_url' ).val()  + '/wp-json/bgbkup/v1/siteurl/?siteurl=https://[NEW_SITE_URL]',
+    method: 'POST',
+    beforeSend: function ( xhr ) {
+        xhr.setRequestHeader( 'X-WP-Nonce', jQuery( '#wp_rest' ).val() );
+    }
+} ).done( function ( response ) {
+    console.log( response );
+} );
+```

--- a/rest/class-boldgrid-backup-rest-siteurl.php
+++ b/rest/class-boldgrid-backup-rest-siteurl.php
@@ -106,22 +106,22 @@ class Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Controller {
 			'title'      => $this->resource,
 			'type'       => 'object',
 			'properties' => [
-				'home'                 => [
+				'home'        => [
 					'context'     => [ 'view' ],
 					'description' => esc_html__( 'Home.', 'boldgrid-backup' ),
 					'type'        => 'string',
 				],
-				'siteurl'                 => [
+				'siteurl'     => [
 					'context'     => [ 'view' ],
 					'description' => esc_html__( 'Siteurl.', 'boldgrid-backup' ),
 					'type'        => 'string',
 				],
-				'old_home'                 => [
+				'old_home'    => [
 					'context'     => [ 'view' ],
 					'description' => esc_html__( 'Old home (before changing).', 'boldgrid-backup' ),
 					'type'        => 'string',
 				],
-				'old_siteurl'                 => [
+				'old_siteurl' => [
 					'context'     => [ 'view' ],
 					'description' => esc_html__( 'Old siteurl (before changing).', 'boldgrid-backup' ),
 					'type'        => 'string',

--- a/rest/class-boldgrid-backup-rest-siteurl.php
+++ b/rest/class-boldgrid-backup-rest-siteurl.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * File: class-boldgrid-backup-rest-siteurl.php
+ *
+ * @link       https://www.boldgrid.com
+ * @since      SINCEVERSION
+ *
+ * @package    Boldgrid_Backup
+ * @copyright  BoldGrid
+ * @version    $Id$
+ * @author     BoldGrid <support@boldgrid.com>
+ */
+
+/**
+ * Class: Boldgrid_Backup_Rest_Siteurl
+ *
+ * REST endpoint for the siteurl.
+ *
+ * @since SINCEVERSION
+ */
+class Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Controller {
+	/**
+	 * Resource name.
+	 *
+	 * @since  SINCEVERSION
+	 * @access private
+	 * @var    string
+	 */
+	protected $resource = 'siteurl';
+
+	/**
+	 * Register the routes for the objects of the controller.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public function register_routes() {
+		$this->register_get();
+		$this->register_update();
+	}
+
+	/**
+	 * Register the route for creating a backup.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public function register_get() {
+		register_rest_route( $this->namespace, '/' . $this->resource, [
+			[
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_item' ],
+				'permission_callback' => [ $this, 'permission_check' ],
+			],
+			'schema' => [ $this, 'get_schema' ],
+		] );
+	}
+
+	/**
+	 * Register router for updating settings.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public function register_update() {
+		register_rest_route( $this->namespace, '/' . $this->resource, [
+			[
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'update_item' ],
+				'permission_callback' => [ $this, 'permission_check' ],
+				'args'                => array(
+					'siteurl' => array(
+						'required'            => true,
+						'description'         => esc_html__( 'New site url.', 'boldgrid-backup' ),
+						'type'                => 'string',
+						'sanitation_callback' => function ( $field ) {
+							return esc_url_raw( $field );
+						},
+					),
+				),
+			],
+			'schema' => [ $this, 'get_schema' ],
+		] );
+	}
+
+	/**
+	 * Prepare the item for the REST response.
+	 *
+	 * @since SINCEVERSION
+	 *
+	 * @param mixed $item WordPress representation of the item.
+	 * @param WP_REST_Request $request Request object.
+	 * @return mixed
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		return $this->filter_schema_properties( $item );
+	}
+
+	/**
+	 * Get schema for settings.
+	 *
+	 * @since SINCEVERSION
+	 *
+	 * @return array Schema Format.
+	 */
+	public function get_schema() {
+		$schema = [
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->resource,
+			'type'       => 'object',
+			'properties' => [
+				'home'                 => [
+					'context'     => [ 'view' ],
+					'description' => esc_html__( 'Home.', 'boldgrid-backup' ),
+					'type'        => 'string',
+				],
+				'siteurl'                 => [
+					'context'     => [ 'view' ],
+					'description' => esc_html__( 'Siteurl.', 'boldgrid-backup' ),
+					'type'        => 'string',
+				],
+				'old_home'                 => [
+					'context'     => [ 'view' ],
+					'description' => esc_html__( 'Old home (before changing).', 'boldgrid-backup' ),
+					'type'        => 'string',
+				],
+				'old_siteurl'                 => [
+					'context'     => [ 'view' ],
+					'description' => esc_html__( 'Old siteurl (before changing).', 'boldgrid-backup' ),
+					'type'        => 'string',
+				],
+			],
+		];
+
+		return $schema;
+	}
+
+	/**
+	 * Get the users plugin settings.
+	 *
+	 * @since SINCEVERSION
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array                   Plugin settings.
+	 */
+	public function get_item( $request ) {
+		return $this->prepare_item_for_response( array(
+			'home'    => get_option( 'home' ),
+			'siteurl' => get_option( 'siteurl' ),
+		), $request );
+	}
+
+	/**
+	 * Update a site url via a REST call.
+	 *
+	 * @since SINCEVERSION
+	 *
+	 * @param  WP_REST_Request $request Request object.
+	 * @return array                    Updated Settings.
+	 */
+	public function update_item( $request ) {
+		$old_home    = get_option( 'home' );
+		$old_siteurl = get_option( 'siteurl' );
+
+		// Get the new site url.
+		$siteurl = $request->get_param( 'siteurl' );
+
+		Boldgrid_Backup_Admin_Utility::update_siteurl( array(
+			'old_siteurl' => $old_siteurl,
+			'siteurl'     => $siteurl,
+			'flush'       => true,
+		) );
+
+		return $this->prepare_item_for_response( array(
+			'old_home'    => $old_home,
+			'old_siteurl' => $old_siteurl,
+			'home'        => get_option( 'home' ),
+			'siteurl'     => get_option( 'siteurl' ),
+		), $request );
+	}
+}

--- a/rest/class-boldgrid-backup-rest-utility.php
+++ b/rest/class-boldgrid-backup-rest-utility.php
@@ -25,9 +25,13 @@ class Boldgrid_Backup_Rest_Utility {
 	 * @return string
 	 */
 	public static function get_current_url() {
-		$protocol = isset( $_SERVER['HTTPS'] ) && 'on' === $_SERVER['HTTPS'] ? 'https' : 'http';
+		$url = '';
 
-		return $protocol . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		if ( ! empty( $_SERVER['HTTP_HOST'] ) ) {
+			$url = ( is_ssl() ? 'https' : 'http' ) . '://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+		}
+
+		return $url;
 	}
 
 	/**

--- a/tests/admin/test-class-boldgrid-backup-admin-utility.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-utility.php
@@ -100,8 +100,8 @@ class Test_Boldgrid_Backup_Admin_Utility extends WP_UnitTestCase {
 		$this->assertTrue( 'Tuesdaay' === $option['days_of_the_week'][2] );
 
 		// Save our option and ensure it's working.
-		$option_value = new stdClass();
-		$option_value->days_of_the_week = new stdClass();
+		$option_value                        = new stdClass();
+		$option_value->days_of_the_week      = new stdClass();
 		$option_value->days_of_the_week->one = 'Monday';
 		$option_value->days_of_the_week->two = 'Tuesday';
 		update_option( 'dow', $option_value );

--- a/tests/admin/test-class-boldgrid-backup-admin-utility.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-utility.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * File: test-class-boldgrid-backup-admin-utility.php
+ *
+ * @link https://www.boldgrid.com
+ * @since     SINCEVERSION
+ *
+ * @package    Boldgrid_Backup
+ * @subpackage Boldgrid_Backup/tests/admin
+ * @copyright  BoldGrid
+ * @version    $Id$
+ * @author     BoldGrid <support@boldgrid.com>
+ */
+
+/**
+ * Class: Test_Boldgrid_Backup_Admin_Utility
+ *
+ * @since SINCEVERSION
+ */
+class Test_Boldgrid_Backup_Admin_Utility extends WP_UnitTestCase {
+	/**
+	 * Test the database find and replace utility.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public function test_db_find_replace() {
+		$post_title   = 'cats and dogs';
+		$post_content = 'Joe has 10 pet cats.';
+
+		$new_post_title   = 'dogs and dogs';
+		$new_post_content = 'Brad has 10 pet cats.';
+
+		$title_find    = 'cats';
+		$title_replace = 'dogs';
+
+		$content_find    = 'Joe';
+		$content_replace = 'Brad';
+
+		$post_id = wp_insert_post( array(
+			'post_title'   => $post_title,
+			'post_content' => $post_content,
+		) );
+
+		// Ensure we created a post.
+		$post = get_post( $post_id );
+		$this->assertTrue( $post_title === $post->post_title );
+		$this->assertTrue( $post_content === $post->post_content );
+
+		// Find and replace on the title only.
+		Boldgrid_Backup_Admin_Utility::db_find_replace( 'posts', 'post_title', $title_find, $title_replace );
+		clean_post_cache( $post_id );
+		$post = get_post( $post_id );
+
+		// Ensure the post title updated.
+		$this->assertTrue( $new_post_title === $post->post_title );
+
+		// Ensure the post content was not touched.
+		$this->assertTrue( $post_content === $post->post_content );
+
+		// Find and replace on the content only.
+		Boldgrid_Backup_Admin_Utility::db_find_replace( 'posts', 'post_content', $content_find, $content_replace );
+		clean_post_cache( $post_id );
+		$post = get_post( $post_id );
+
+		// Ensure the post title was not touched.
+		$this->assertTrue( $new_post_title === $post->post_title );
+
+		// Ensure the post content was updated.
+		$this->assertTrue( $new_post_content === $post->post_content );
+	}
+
+	/**
+	 * Test the option find and replace function.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public function test_option_find_replace() {
+		// Save our option and ensure it's working as expected.
+		update_option(
+			'dow',
+			array(
+				'days_of_the_week' => array(
+					1 => 'Monday',
+					2 => 'Tuesday',
+				),
+			)
+		);
+		$option = get_option( 'dow' );
+		$this->assertTrue( 'Monday' === $option['days_of_the_week'][1] );
+
+		// Replace an entire value.
+		Boldgrid_Backup_Admin_Utility::option_find_replace( 'Monday', 'Funday' );
+		$option = get_option( 'dow' );
+		$this->assertTrue( 'Funday' === $option['days_of_the_week'][1] );
+
+		// Replace part of a value.
+		Boldgrid_Backup_Admin_Utility::option_find_replace( 'day', 'daay' );
+		$option = get_option( 'dow' );
+		$this->assertTrue( 'Fundaay' === $option['days_of_the_week'][1] );
+		$this->assertTrue( 'Tuesdaay' === $option['days_of_the_week'][2] );
+
+		// Save our option and ensure it's working.
+		$option_value = new stdClass();
+		$option_value->days_of_the_week = new stdClass();
+		$option_value->days_of_the_week->one = 'Monday';
+		$option_value->days_of_the_week->two = 'Tuesday';
+		update_option( 'dow', $option_value );
+		$option = get_option( 'dow' );
+		$this->assertTrue( 'Monday' === $option->days_of_the_week->one );
+
+		// Replace an entire value.
+		Boldgrid_Backup_Admin_Utility::option_find_replace( 'Monday', 'Funday' );
+		$option = get_option( 'dow' );
+		$this->assertTrue( 'Funday' === $option->days_of_the_week->one );
+
+		// Replace part of a value.
+		Boldgrid_Backup_Admin_Utility::option_find_replace( 'day', 'daay' );
+		$option = get_option( 'dow' );
+		$this->assertTrue( 'Fundaay' === $option->days_of_the_week->one );
+		$this->assertTrue( 'Tuesdaay' === $option->days_of_the_week->two );
+	}
+}

--- a/tests/rest/class-boldgrid-backup-rest-case.php
+++ b/tests/rest/class-boldgrid-backup-rest-case.php
@@ -57,6 +57,7 @@ class Boldgrid_Backup_Rest_Case extends WP_UnitTestCase {
 		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-archive.php';
 		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-setting.php';
 		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-test.php';
+		require_once BOLDGRID_BACKUP_PATH . '/rest/class-boldgrid-backup-rest-siteurl.php';
 
 		// Register REST endpoints.
 		$core = new Boldgrid_Backup_Admin_Core();
@@ -72,6 +73,9 @@ class Boldgrid_Backup_Rest_Case extends WP_UnitTestCase {
 
 			$rest_test = new Boldgrid_Backup_Rest_Test( $core );
 			$rest_test->register_routes();
+
+			$rest_siteurl = new Boldgrid_Backup_Rest_Siteurl( $core );
+			$rest_siteurl->register_routes();
 		} );
 
 		// Initiate the REST API.

--- a/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
+++ b/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
@@ -73,6 +73,12 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 		$this->assertTrue( 400 === $data['data']['status'] );
 		$this->assertTrue( 'rest_missing_callback_param' === $data['code'] );
 
+		// Before we change the site url, let's create a post with a link in it.
+		$post_id = wp_insert_post( array(
+			'post_title'   => 'Test post',
+			'post_content' => 'A link to <a href="http://example.org/about-us">about us</a>.',
+		) );
+
 		$request = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
 		$request->set_body_params( array(
 			'siteurl' => 'http://example.com',
@@ -89,6 +95,11 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 		// Validate some options.
 		$this->assertTrue( 'http://example.com' === get_option( 'home' ) );
 		$this->assertTrue( 'http://example.com' === get_option( 'siteurl' ) );
+
+		// Ensure the link in our post was updated.
+		clean_post_cache( $post_id );
+		$post = get_post( $post_id );
+		$this->assertTrue( false !== strpos( $post->post_content, 'http://example.com/about-us' ) );
 
 		// Test and make sure we don't get weird find / replace issues.
 		$request = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
@@ -107,5 +118,10 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 		// Validate some options.
 		$this->assertTrue( 'http://example.com/514/514' === get_option( 'home' ) );
 		$this->assertTrue( 'http://example.com/514/514' === get_option( 'siteurl' ) );
+
+		// Ensure the link in our post was updated.
+		clean_post_cache( $post_id );
+		$post = get_post( $post_id );
+		$this->assertTrue( false !== strpos( $post->post_content, 'http://example.com/514/514/about-us' ) );
 	}
 }

--- a/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
+++ b/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * File: test-class-boldgrid-backup-rest-siteurl.php
+ *
+ * @link https://www.boldgrid.com
+ * @since SINCEVERSION
+ *
+ * @package    Boldgrid_Backup
+ * @subpackage Boldgrid_Backup/tests/rest
+ * @copyright  BoldGrid
+ * @author     BoldGrid <support@boldgrid.com>
+ */
+
+/**
+ * Class: Test_Boldgrid_Backup_Rest_Siteurl
+ *
+ * @since SINCEVERSION
+ */
+class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
+	/**
+	 * Test get_item.
+	 *
+	 * @since SINCEVERISON
+	 */
+	public function test_get_item() {
+		wp_set_current_user( $this->editor_id );
+
+		$request  = new WP_REST_Request( 'GET', '/bgbkup/v1/siteurl' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Ensure we don't have permission as an editor.
+		$this->assertTrue( 403 === $data['data']['status'] );
+
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/bgbkup/v1/siteurl' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Validate the data we got back from the rest call.
+		$this->assertTrue( 'http://example.org' === $data['home'] );
+		$this->assertTrue( 'http://example.org' === $data['siteurl'] );
+		$this->assertTrue( empty( $data['old_home'] ) );
+		$this->assertTrue( empty( $data['old_siteurl'] ) );
+	}
+
+	/**
+	 * Test update item.
+	 *
+	 * @since SINCEVERSION
+	 */
+	public function test_update_item() {
+		wp_set_current_user( $this->editor_id );
+
+		$request  = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
+		$request->set_body_params( array(
+			'siteurl' => 'http://example.com',
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Ensure we don't have permission as an editor.
+		$this->assertTrue( 403 === $data['data']['status'] );
+
+		wp_set_current_user( $this->admin_id );
+
+		$request  = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// We forgot to pass in our siteurl and should get an error.
+		$this->assertTrue( 400 === $data['data']['status'] );
+		$this->assertTrue( 'rest_missing_callback_param' === $data['code'] );
+
+		$request  = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
+		$request->set_body_params( array(
+			'siteurl' => 'http://example.com',
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Validate the data we got back after changing the site url.
+		$this->assertTrue( 'http://example.com' === $data['home'] );
+		$this->assertTrue( 'http://example.com' === $data['siteurl'] );
+		$this->assertTrue( 'http://example.org' === $data['old_home'] );
+		$this->assertTrue( 'http://example.org' === $data['old_siteurl']);
+
+		// Validate some options.
+		$this->assertTrue( 'http://example.com' === get_option( 'home') );
+		$this->assertTrue( 'http://example.com' === get_option( 'siteurl') );
+	}
+}

--- a/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
+++ b/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
@@ -53,7 +53,7 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 	public function test_update_item() {
 		wp_set_current_user( $this->editor_id );
 
-		$request  = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
+		$request = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
 		$request->set_body_params( array(
 			'siteurl' => 'http://example.com',
 		) );
@@ -73,7 +73,7 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 		$this->assertTrue( 400 === $data['data']['status'] );
 		$this->assertTrue( 'rest_missing_callback_param' === $data['code'] );
 
-		$request  = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
+		$request = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
 		$request->set_body_params( array(
 			'siteurl' => 'http://example.com',
 		) );
@@ -84,10 +84,10 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 		$this->assertTrue( 'http://example.com' === $data['home'] );
 		$this->assertTrue( 'http://example.com' === $data['siteurl'] );
 		$this->assertTrue( 'http://example.org' === $data['old_home'] );
-		$this->assertTrue( 'http://example.org' === $data['old_siteurl']);
+		$this->assertTrue( 'http://example.org' === $data['old_siteurl'] );
 
 		// Validate some options.
-		$this->assertTrue( 'http://example.com' === get_option( 'home') );
-		$this->assertTrue( 'http://example.com' === get_option( 'siteurl') );
+		$this->assertTrue( 'http://example.com' === get_option( 'home' ) );
+		$this->assertTrue( 'http://example.com' === get_option( 'siteurl' ) );
 	}
 }

--- a/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
+++ b/tests/rest/class-test-boldgrid-backup-rest-siteurl.php
@@ -89,5 +89,23 @@ class Test_Boldgrid_Backup_Rest_Siteurl extends Boldgrid_Backup_Rest_Case {
 		// Validate some options.
 		$this->assertTrue( 'http://example.com' === get_option( 'home' ) );
 		$this->assertTrue( 'http://example.com' === get_option( 'siteurl' ) );
+
+		// Test and make sure we don't get weird find / replace issues.
+		$request = new WP_REST_Request( 'POST', '/bgbkup/v1/siteurl' );
+		$request->set_body_params( array(
+			'siteurl' => 'http://example.com/514/514',
+		) );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		// Validate the data we got back after changing the site url.
+		$this->assertTrue( 'http://example.com/514/514' === $data['home'] );
+		$this->assertTrue( 'http://example.com/514/514' === $data['siteurl'] );
+		$this->assertTrue( 'http://example.com' === $data['old_home'] );
+		$this->assertTrue( 'http://example.com' === $data['old_siteurl'] );
+
+		// Validate some options.
+		$this->assertTrue( 'http://example.com/514/514' === get_option( 'home' ) );
+		$this->assertTrue( 'http://example.com/514/514' === get_option( 'siteurl' ) );
 	}
 }


### PR DESCRIPTION
Add this to your wp-config.php:
```define( 'WP_ENVIRONMENT_TYPE', 'development' );```

Change the site url (run via js console)
```
jQuery.ajax( {
    url: jQuery( '#bgbkup_site_url' ).val()  + '/wp-json/bgbkup/v1/siteurl/?siteurl=https://wpbex2-dev-bradm.boldgrid.com/single-site-joec',
    method: 'POST',
    beforeSend: function ( xhr ) {
        xhr.setRequestHeader( 'X-WP-Nonce', jQuery( '#wp_rest' ).val() );
    }
} ).done( function ( response ) {
    console.log( response );
} );
```

You'll get this back.
```
{home: 'https://wpbex2-dev-bradm.boldgrid.com/single-site-joec', siteurl: 'https://wpbex2-dev-bradm.boldgrid.com/single-site-joec', old_home: 'https://wpbex2-dev-bradm.boldgrid.com/single-site-1', old_siteurl: 'https://wpbex2-dev-bradm.boldgrid.com/single-site-1'}
```

Rename your directory.
`mv single-site-1 single-site-joec`

Test your site.