### PR TITLE
Rework PDO Connections for Sockets

### DIFF
--- a/admin/class-boldgrid-backup-admin-db-dump.php
+++ b/admin/class-boldgrid-backup-admin-db-dump.php
@@ -256,17 +256,4 @@ class Boldgrid_Backup_Admin_Db_Dump {
 
 		return $tables;
 	}
-
-	/**
-	 * Deprecated, use Boldgrid_Backup_Admin_Utility::get_pdo_connection_string.
-	 *
-	 * @since 1.15.8
-	 *
-	 * @param  string $db_host DB hostname.
-	 * @param  string $db_name DB name.
-	 * @return string
-	 */
-	public function get_connection_string( $db_host = null, $db_name = null ) {
-		return Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( $db_host, $db_name );
-	}
 }

--- a/admin/class-boldgrid-backup-admin-db-dump.php
+++ b/admin/class-boldgrid-backup-admin-db-dump.php
@@ -122,7 +122,7 @@ class Boldgrid_Backup_Admin_Db_Dump {
 
 		try {
 			$dump = new IMysqldump\Mysqldump(
-				$this->get_connection_string(),
+				Boldgrid_Backup_Admin_Utility::get_pdo_connection_string(),
 				DB_USER,
 				DB_PASSWORD,
 				$settings
@@ -140,71 +140,6 @@ class Boldgrid_Backup_Admin_Db_Dump {
 		do_action( 'boldgrid_backup_post_dump', $file );
 
 		return true;
-	}
-
-	/**
-	 * Get our PDO DSN connection string.
-	 *
-	 * @since 1.13.3
-	 *
-	 * @param  string $db_host DB hostname.
-	 * @param  string $db_name DB name.
-	 * @return string
-	 */
-	public function get_connection_string( $db_host = null, $db_name = null ) {
-		$params = array();
-
-		// Configure parameters passed in.
-		$db_name = empty( $db_name ) ? DB_NAME : $db_name;
-		$db_host = empty( $db_host ) ? DB_HOST : $db_host;
-		$db_host = explode( ':', $db_host );
-
-		// Parse info and get hostname, port, and socket. Not all required. See comments below.
-		switch ( count( $db_host ) ) {
-			/*
-			 * Examples:
-			 *
-			 * # localhost
-			 * # /var/lib/mysql/mysql.sock
-			 */
-			case 1:
-				$has_socket = 'sock' === pathinfo( $db_host[0], PATHINFO_EXTENSION );
-
-				if ( $has_socket ) {
-					$params['unix_socket'] = $db_host[0];
-				} else {
-					$params['host'] = $db_host[0];
-				}
-
-				break;
-			/*
-			 * Examples:
-			 *
-			 * # localhost:/var/lib/mysql/mysql.sock
-			 * # localhost:3306
-			 */
-			case 2:
-				$has_socket = 'sock' === pathinfo( $db_host[1], PATHINFO_EXTENSION );
-				$has_port   = is_numeric( $db_host[1] );
-
-				$params['host'] = $db_host[0];
-
-				if ( $has_socket ) {
-					$params['unix_socket'] = $db_host[1];
-				} elseif ( $has_port ) {
-					$params['port'] = $db_host[1];
-				}
-
-				break;
-		}
-
-		$connection_string = 'mysql:';
-		foreach ( $params as $key => $value ) {
-			$connection_string .= $key . '=' . $value . ';';
-		}
-		$connection_string .= 'dbname=' . $db_name;
-
-		return $connection_string;
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin-db-dump.php
+++ b/admin/class-boldgrid-backup-admin-db-dump.php
@@ -256,4 +256,17 @@ class Boldgrid_Backup_Admin_Db_Dump {
 
 		return $tables;
 	}
+
+	/**
+	 * Deprecated, use Boldgrid_Backup_Admin_Utility::get_pdo_connection_string.
+	 *
+	 * @since 1.15.8
+	 *
+	 * @param  string $db_host DB hostname.
+	 * @param  string $db_name DB name.
+	 * @return string
+	 */
+	public function get_connection_string( $db_host = null, $db_name = null ) {
+		return Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( $db_host, $db_name );
+	}
 }

--- a/admin/class-boldgrid-backup-admin-db-import.php
+++ b/admin/class-boldgrid-backup-admin-db-import.php
@@ -151,7 +151,7 @@ class Boldgrid_Backup_Admin_Db_Import {
 		}
 
 		/* phpcs:disable WordPress.DB.RestrictedClasses */
-		$db = new PDO( sprintf( 'mysql:host=%1$s;dbname=%2$s;', DB_HOST, DB_NAME ), DB_USER, DB_PASSWORD );
+		$db = new PDO( Boldgrid_Backup_Admin_Utility::get_pdo_connection_string(), DB_USER, DB_PASSWORD );
 
 		$templine = '';
 
@@ -331,7 +331,7 @@ class Boldgrid_Backup_Admin_Db_Import {
 	 * @return array an array of results from the database query
 	 */
 	public function show_grants_query() {
-		$db           = new PDO( sprintf( 'mysql:host=%1$s;dbname=%2$s;', DB_HOST, DB_NAME ), DB_USER, DB_PASSWORD );
+		$db           = new PDO( Boldgrid_Backup_Admin_Utility::get_pdo_connection_string(), DB_USER, DB_PASSWORD );
 		$db_statement = $db->query( 'SHOW GRANTS' );
 		return $db_statement->fetchAll();
 	}

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -1035,7 +1035,7 @@ class Boldgrid_Backup_Admin_Utility {
 		if ( isset( $socket ) ) {
 			$params['unix_socket'] = $socket;
 		}
-		//If only a socket is provided, without a ':' character before it, the entire array will be empty not false
+		// If only a socket is provided, without a ':' character before it, the entire array will be empty not false.
 		if ( count( $params ) === 0 ) {
 			$params['unix_socket'] = $db_host;
 		}

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -1016,7 +1016,7 @@ class Boldgrid_Backup_Admin_Utility {
 		// Configure parameters passed in.
 		$db_name = empty( $db_name ) ? DB_NAME : $db_name;
 		$db_host = empty( $db_host ) ? DB_HOST : $db_host;
-		
+
 		// Parse info and get hostname, port, and socket. False if fails to parse.
 		$host_data = $wpdb->parse_db_host( $db_host );
 

--- a/admin/class-boldgrid-backup-admin-utility.php
+++ b/admin/class-boldgrid-backup-admin-utility.php
@@ -999,4 +999,53 @@ class Boldgrid_Backup_Admin_Utility {
 
 		return untrailingslashit( $string ) . DIRECTORY_SEPARATOR;
 	}
+
+	/**
+	 * Get our PDO DSN connection string.
+	 *
+	 * @since 1.15.8
+	 *
+	 * @param  string $db_host DB hostname.
+	 * @param  string $db_name DB name.
+	 * @return string
+	 */
+	public static function get_pdo_connection_string( $db_host = null, $db_name = null ) {
+		global $wpdb;
+		$params = array();
+
+		// Configure parameters passed in.
+		$db_name = empty( $db_name ) ? DB_NAME : $db_name;
+		$db_host = empty( $db_host ) ? DB_HOST : $db_host;
+		
+		// Parse info and get hostname, port, and socket. False if fails to parse.
+		$host_data = $wpdb->parse_db_host( $db_host );
+
+		if ( $host_data ) {
+			list( $host, $port, $socket, $is_ipv6 ) = $host_data;
+		} else {
+			return '';
+		}
+
+		if ( ! empty( $host ) ) {
+			$params['host'] = $host;
+		}
+		if ( isset( $port ) ) {
+			$params['port'] = $port;
+		}
+		if ( isset( $socket ) ) {
+			$params['unix_socket'] = $socket;
+		}
+		//If only a socket is provided, without a ':' character before it, the entire array will be empty not false
+		if ( count( $params ) === 0 ) {
+			$params['unix_socket'] = $db_host;
+		}
+
+		$connection_string = 'mysql:';
+		foreach ( $params as $key => $value ) {
+			$connection_string .= $key . '=' . $value . ';';
+		}
+		$connection_string .= 'dbname=' . $db_name;
+
+		return $connection_string;
+	}
 }

--- a/cli/class-info.php
+++ b/cli/class-info.php
@@ -253,6 +253,7 @@ class Info {
 	 */
 	public static function have_execution_functions() {
 		require_once dirname( __DIR__ ) . '/admin/class-boldgrid-backup-admin-cli.php';
+		require_once dirname( __DIR__ ) . '/admin/class-boldgrid-backup-admin-utility.php';
 
 		$exec_functions = \Boldgrid_Backup_Admin_Cli::get_execution_functions();
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require-dev" : {
 		"lox/xhprof" : "dev-master",
 		"phpunit/phpunit": "^7",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"scripts" : {
 		"post-autoload-dump" : "composer run-script post-autoload-dump -d ./vendor/boldgrid/library"

--- a/composer.lock
+++ b/composer.lock
@@ -1852,7 +1852,7 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",

--- a/tests/admin/test-class-boldgrid-backup-admin-db-dump.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-db-dump.php
@@ -29,25 +29,25 @@ class Test_Boldgrid_Backup_Admin_Db_Dump extends WP_UnitTestCase {
 		// localhost.
 		$this->assertEquals(
 			'mysql:host=localhost;dbname=db_catfish',
-			$core->db_dump->get_connection_string( 'localhost', 'db_catfish' )
+			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( 'localhost', 'db_catfish' )
 		);
 
 		// localhost:3306.
 		$this->assertEquals(
 			'mysql:host=localhost;port=3306;dbname=db_catfish',
-			$core->db_dump->get_connection_string( 'localhost:3306', 'db_catfish' )
+			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( 'localhost:3306', 'db_catfish' )
 		);
 
 		// localhost:/var/lib/mysql/mysql.sock.
 		$this->assertEquals(
 			'mysql:host=localhost;unix_socket=/var/lib/mysql/mysql.sock;dbname=db_catfish',
-			$core->db_dump->get_connection_string( 'localhost:/var/lib/mysql/mysql.sock', 'db_catfish' )
+			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( 'localhost:/var/lib/mysql/mysql.sock', 'db_catfish' )
 		);
 
 		// /var/lib/mysql/mysql.sock.
 		$this->assertEquals(
 			'mysql:unix_socket=/var/lib/mysql/mysql.sock;dbname=db_catfish',
-			$core->db_dump->get_connection_string( '/var/lib/mysql/mysql.sock', 'db_catfish' )
+			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( '/var/lib/mysql/mysql.sock', 'db_catfish' )
 		);
 	}
 }

--- a/tests/admin/test-class-boldgrid-backup-admin-db-dump.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-db-dump.php
@@ -29,25 +29,25 @@ class Test_Boldgrid_Backup_Admin_Db_Dump extends WP_UnitTestCase {
 		// localhost.
 		$this->assertEquals(
 			'mysql:host=localhost;dbname=db_catfish',
-			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( 'localhost', 'db_catfish' )
+			$core->utility->get_pdo_connection_string( 'localhost', 'db_catfish' )
 		);
 
 		// localhost:3306.
 		$this->assertEquals(
 			'mysql:host=localhost;port=3306;dbname=db_catfish',
-			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( 'localhost:3306', 'db_catfish' )
+			$core->utility->get_pdo_connection_string( 'localhost:3306', 'db_catfish' )
 		);
 
 		// localhost:/var/lib/mysql/mysql.sock.
 		$this->assertEquals(
 			'mysql:host=localhost;unix_socket=/var/lib/mysql/mysql.sock;dbname=db_catfish',
-			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( 'localhost:/var/lib/mysql/mysql.sock', 'db_catfish' )
+			$core->utility->get_pdo_connection_string( 'localhost:/var/lib/mysql/mysql.sock', 'db_catfish' )
 		);
 
 		// /var/lib/mysql/mysql.sock.
 		$this->assertEquals(
 			'mysql:unix_socket=/var/lib/mysql/mysql.sock;dbname=db_catfish',
-			Boldgrid_Backup_Admin_Utility::get_pdo_connection_string( '/var/lib/mysql/mysql.sock', 'db_catfish' )
+			$core->utility->get_pdo_connection_string( '/var/lib/mysql/mysql.sock', 'db_catfish' )
 		);
 	}
 }


### PR DESCRIPTION
Resolves #572 
Moved `Class_Boldgrid_Backup_Admin_Db_Dump->get_connection_string` to static `Class_Boldgrid_Backup_Admin_Util::get_pdo_connection_string` and refactored to use the core parse_db_host function rather than custom logic.