### PR TITLE
Copy PDO Connection string from db-dump to db-import

### DIFF
--- a/admin/class-boldgrid-backup-admin-db-import.php
+++ b/admin/class-boldgrid-backup-admin-db-import.php
@@ -381,7 +381,7 @@ class Boldgrid_Backup_Admin_Db_Import {
 	 * This function is copied from class-boldgrid-backup-admin-db-dump.php. It hasn't been migrated to a utility function
 	 * because these scripts are designed to be able to run without WordPress from the command line, including without the
 	 * core wpdb::parse_db_host() function.
-	 * 
+	 *
 	 * @since 1.15.8
 	 *
 	 * @param  string $db_host DB hostname.

--- a/admin/class-boldgrid-backup-admin-log.php
+++ b/admin/class-boldgrid-backup-admin-log.php
@@ -130,7 +130,7 @@ class Boldgrid_Backup_Admin_Log {
 		$current_error = error_get_last();
 
 		// Only new fatal are logged.
-		if ( 1 === $current_error['type'] ) {
+		if ( is_array( $current_error ) && 1 === $current_error['type'] ) {
 			$this->add( 'Last error: ' . print_r( $current_error, 1 ), false ); // phpcs:ignore
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require-dev" : {
 		"lox/xhprof" : "dev-master",
 		"phpunit/phpunit": "^7",
-		"yoast/phpunit-polyfills": "^1.0"
+		"yoast/phpunit-polyfills": "^2.0"
 	},
 	"scripts" : {
 		"post-autoload-dump" : "composer run-script post-autoload-dump -d ./vendor/boldgrid/library"

--- a/composer.lock
+++ b/composer.lock
@@ -1852,7 +1852,7 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Total Upkeep – WordPress Backup Plugin plus Restore & Migrate by BoldGrid ===
-Contributors: boldgrid, joemoto, imh_brad, rramo012, bgnicolepaschen, jamesros161, joe9663, weaponx13
+Contributors: boldgrid, joemoto, imh_brad, rramo012, bgnicolepaschen, jamesros161, joe9663, weaponx13, jessecowens
 Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 4.4
 Tested up to: 6.2


### PR DESCRIPTION
Resolves #574.

After consulting with @jamesros161, we decided the best method to update this function was to copy the function rather than moving it to the utility class. This is because the scripts are meant to be able to run atomically via CLI without WordPress or the rest of the plugin in the event of catastrophic failure. Similarly, we're not using the core wpdb:parse_db_host() since wpdb will not be instantiated during a CLI restoration. 