### PR TITLE
Cron interval

### DIFF
--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -207,7 +207,7 @@ class Boldgrid_Backup_Admin_Cron {
 				$scheduled = $this->add_cron_entry( $settings );
 			}
 
-			$jobs_scheduled = $this->schedule_jobs();
+			$jobs_scheduled = $this->schedule_jobs( $settings );
 			$site_check     = $this->schedule_site_check( $settings );
 
 			$success = $scheduled && $jobs_scheduled;
@@ -313,17 +313,21 @@ class Boldgrid_Backup_Admin_Cron {
 	 * @see BoldGrid_Backup_Admin_Core::get_backup_identifier()
 	 * @see BoldGrid_Backup_Admin_Cron::get_cron_secret()
 	 *
+	 * @param  array $settings Settings.
+	 *
 	 * @return bool Success.
 	 */
-	public function schedule_jobs() {
-		$entry = sprintf(
-			'*/5 * * * * %6$s "%1$s/%2$s" siteurl=%3$s id=%4$s secret=%5$s > /dev/null 2>&1',
+	public function schedule_jobs( $settings ) {
+		$cron_interval = isset( $settings['cron_interval'] ) ? $settings['cron_interval'] : '*/10 * * * *';
+		$entry         = sprintf(
+			'%7$s %6$s "%1$s/%2$s" siteurl=%3$s id=%4$s secret=%5$s > /dev/null 2>&1',
 			dirname( dirname( __FILE__ ) ),
 			$this->run_jobs,
 			get_site_url(),
 			$this->core->get_backup_identifier(),
 			$this->get_cron_secret(),
-			$this->cron_command
+			$this->cron_command,
+			$cron_interval
 		);
 
 		return $this->update_cron( $entry );

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -274,7 +274,24 @@ class Boldgrid_Backup_Admin_Jobs {
 	public function run() {
 		$this->set_jobs();
 
-		// If there are no jobs, then delete cron entries and abort.
+		/*
+		 * If there are no jobs in the job list, then delete this cron.
+		 * Please note, that this method is called by the cron itself,
+		 * so it will only delete if the cron list is empty when the cron starts.
+		 * Sometimes, the job will have completed, but not have been removed from the list yet.
+		 * In this case, the cron will not delete itself until the next scheduled cron run.
+		 *
+		 * The basic pattern is this:
+		 * 1. Automatic backup is scheduled.
+		 * 2. Automatic backup is run.
+		 * 3. While automatic backup is running, if remote storage is enabled,
+		 *    the run-jobs.php cron is added.
+		 * 4. When automatic backup is complete, the upload backup job is added to the cron list.
+		 * 5. Next time the run-jobs.php cron runs, the upload backup job is run.
+		 * 6. The next time the run-jobs.php cron runs, the upload backup job is deleted.
+		 * 7. The next time the run-jobs.php cron runs, the run-jobs.php cron is deleted.
+		 * 8. Repeat.
+		 */
 		if ( empty( $this->jobs ) ) {
 			$this->core->cron->delete_cron_entries( 'jobs' );
 			wp_die();

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -274,8 +274,14 @@ class Boldgrid_Backup_Admin_Jobs {
 	public function run() {
 		$this->set_jobs();
 
-		// If there are no jobs or already running, then abort.
-		if ( empty( $this->jobs ) || $this->is_running() ) {
+		// If there are no jobs, then delete cron entries and abort.
+		if ( empty( $this->jobs ) ) {
+			$this->core->cron->delete_cron_entries( 'cron/run-jobs.php' );
+			wp_die();
+		}
+
+		// If we have a job currently running, abort.
+		if ( $this->is_running() ) {
 			wp_die();
 		}
 

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -276,7 +276,7 @@ class Boldgrid_Backup_Admin_Jobs {
 
 		// If there are no jobs, then delete cron entries and abort.
 		if ( empty( $this->jobs ) ) {
-			$this->core->cron->delete_cron_entries( 'cron/run-jobs.php' );
+			$this->core->cron->delete_cron_entries( 'jobs' );
 			wp_die();
 		}
 

--- a/admin/class-boldgrid-backup-admin-settings.php
+++ b/admin/class-boldgrid-backup-admin-settings.php
@@ -740,6 +740,15 @@ class Boldgrid_Backup_Admin_Settings {
 			}
 
 			/*
+			 * Save cron interval Settings.
+			 *
+			 * @since 1.16.0
+			 */
+			if ( isset( $_POST['cron_interval'] ) ) {
+				$settings['cron_interval'] = $_POST['cron_interval'];
+			}
+
+			/*
 			 * Save WP Cron / Crons.
 			 *
 			 * @since 1.5.1

--- a/admin/js/boldgrid-backup-admin-settings.js
+++ b/admin/js/boldgrid-backup-admin-settings.js
@@ -298,23 +298,27 @@ BoldGrid.Settings = function( $ ) {
 	 * Toggle Cron Interval
 	 *
 	 * @summary Toggle the cron interval select element.
-	 * 
+	 *
 	 * @since 1.16.0
 	 */
 	self.toggleCronInterval = function() {
-		var $schedulerSelect   = $( 'select[name="scheduler"]' ),
-			toggleInterval     = function( val ) {
-			if ( 'cron' === val ) {
-				$( '#cron_interval' ).show();
-			} else {
-				$( '#cron_interval' ).hide();
-			}
-		}
+		var $schedulerSelect = $( 'select[name="scheduler"]' ),
+			toggleInterval = function( val ) {
+				if ( 'cron' === val ) {
+					$( '#cron_interval' ).show();
+				} else {
+					$( '#cron_interval' ).hide();
+				}
+			};
 
 		toggleInterval( $schedulerSelect.find( 'option:selected' ).val() );
 
 		$schedulerSelect.on( 'change', function() {
-			toggleInterval( $( this ).find( 'option:selected' ).val() );
+			toggleInterval(
+				$( this )
+					.find( 'option:selected' )
+					.val()
+			);
 		} );
 	};
 

--- a/admin/js/boldgrid-backup-admin-settings.js
+++ b/admin/js/boldgrid-backup-admin-settings.js
@@ -294,6 +294,30 @@ BoldGrid.Settings = function( $ ) {
 		}
 	};
 
+	/**
+	 * Toggle Cron Interval
+	 *
+	 * @summary Toggle the cron interval select element.
+	 * 
+	 * @since 1.16.0
+	 */
+	self.toggleCronInterval = function() {
+		var $schedulerSelect   = $( 'select[name="scheduler"]' ),
+			toggleInterval     = function( val ) {
+			if ( 'cron' === val ) {
+				$( '#cron_interval' ).show();
+			} else {
+				$( '#cron_interval' ).hide();
+			}
+		}
+
+		toggleInterval( $schedulerSelect.find( 'option:selected' ).val() );
+
+		$schedulerSelect.on( 'change', function() {
+			toggleInterval( $( this ).find( 'option:selected' ).val() );
+		} );
+	};
+
 	// Onload event listener.
 	$( function() {
 
@@ -303,6 +327,8 @@ BoldGrid.Settings = function( $ ) {
 		self.toggleNoStorage();
 
 		self.toggleCompressionInfo();
+
+		self.toggleCronInterval();
 
 		$body.on( 'click', '#storage_locations input[type="checkbox"]', self.toggleNoStorage );
 

--- a/admin/partials/settings/scheduler.php
+++ b/admin/partials/settings/scheduler.php
@@ -45,6 +45,29 @@ foreach ( $schedulers_available as $key => $scheduler_data ) {
 
 $scheduler_select = sprintf( '<select name="scheduler" id="scheduler">%1$s</select>', $scheduler_options );
 
+$intervals = array(
+	'*/5 * * * *'  => esc_html__( 'Every 5 Minutes', 'boldgrid-backup' ),
+	'*/10 * * * *' => esc_html__( 'Every 10 Minutes', 'boldgrid-backup' ),
+	'*/30 * * * *' => esc_html__( 'Every 30 Minutes', 'boldgrid-backup' ),
+	'0 * * * *'    => esc_html__( 'Once Every Hour', 'boldgrid-backup' ),
+	'0 0 * * *'    => esc_html__( 'Once Every Day', 'boldgrid-backup' ),
+);
+
+$selected_interval = ! empty( $settings['cron_interval'] ) ? $settings['cron_interval'] : '*/10 * * * *';
+
+$cron_interval_options = '';
+
+foreach ( $intervals as $key => $interval ) {
+	$cron_interval_options .= sprintf(
+		'<option value="%1$s" %3$s>%2$s</option>',
+		$key,
+		$interval,
+		$key === $selected_interval ? 'selected="selected"' : ''
+	);
+}
+
+$cron_interval_select = sprintf( '<select name="cron_interval" id="cron_interval">%1$s</select>', $cron_interval_options );
+
 return sprintf(
 	'
 	<div class="bg-box">
@@ -54,10 +77,12 @@ return sprintf(
 		<div class="bg-box-bottom">
 			%2$s
 			%3$s
+			%5$s
 		</div>
 	</div>',
 	__( 'Scheduler', 'boldgrid-backup' ),
 	$scheduler_select,
 	$wp_cron_warning,
-	__( 'Advanced', 'boldgrid-backup' )
+	__( 'Advanced', 'boldgrid-backup' ),
+	$cron_interval_select
 );

--- a/admin/partials/settings/scheduler.php
+++ b/admin/partials/settings/scheduler.php
@@ -50,7 +50,6 @@ $intervals = array(
 	'*/10 * * * *' => esc_html__( 'Every 10 Minutes', 'boldgrid-backup' ),
 	'*/30 * * * *' => esc_html__( 'Every 30 Minutes', 'boldgrid-backup' ),
 	'0 * * * *'    => esc_html__( 'Once Every Hour', 'boldgrid-backup' ),
-	'0 0 * * *'    => esc_html__( 'Once Every Day', 'boldgrid-backup' ),
 );
 
 $selected_interval = ! empty( $settings['cron_interval'] ) ? $settings['cron_interval'] : '*/10 * * * *';

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.16.0
+ *          Version: 1.16.0-rc.1
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.15.10
+ *          Version: 1.16.0
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.16.0-rc.1
+ *          Version: 1.16.0
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 4.4
 Tested up to: 6.4
 Requires PHP: 5.4
-Stable tag: 1.15.10
+Stable tag: 1.16.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -131,6 +131,10 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 1. Activate the plugin through the Plugins menu in WordPress.
 
 == Changelog ==
+
+= 1.16.0 =
+Release Date: February 20, 2024
+* New Feature: Add settings for cron interval for run-jobs.php [#584](https://github.com/BoldGrid/boldgrid-backup/issues/584)
 
 = 1.15.10 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -133,7 +133,7 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 == Changelog ==
 
 = 1.16.0 =
-Release Date: February 20, 2024
+Release Date: February 26, 2024
 * New Feature: Add settings for cron interval for run-jobs.php [#584](https://github.com/BoldGrid/boldgrid-backup/issues/584)
 
 = 1.15.10 =


### PR DESCRIPTION
Resolves #584

## Test File ##
[boldgrid-backup.1.16.0-rc.1.zip](https://github.com/BoldGrid/boldgrid-backup/files/14350193/boldgrid-backup.1.16.0-rc.1.zip)

## Testing Instructions ##
1. Install the test zip file.
2. In the Total Upkeep settings page, set the cron interval
![image](https://github.com/BoldGrid/boldgrid-backup/assets/49331357/32d1baa4-e5e6-4576-b74c-8f1facbf971a)
3. Setup a remote storage such as Google Drive
4. Setup an automatic backup to take place.
5. Check the crontab in your terminal to verify that the interval for run-jobs.php matches what you selected.
6. Once the Automatic backup finishes, a job should get added to the jobs list to upload the file to google drive.
7. Ensure that the cron runs at the appropriate interval.
8. Once the jobs list is completed, on the following interval, the cron job should be removed from the crontab. Check it to ensure this is the case.