### PR TITLE
validate cron interval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ script:
 before_deploy:
   - yes | gem update --system --force
   - gem install bundler
+  - gem install faraday-net_http -v '3.3.0'
   - gem install uri
   - gem install logger
 

--- a/admin/class-boldgrid-backup-admin-scheduler.php
+++ b/admin/class-boldgrid-backup-admin-scheduler.php
@@ -121,6 +121,17 @@ class Boldgrid_Backup_Admin_Scheduler {
 	}
 
 	/**
+	 * Get cron intervals.
+	 * 
+	 * @since SINCEVERSION
+	 * 
+	 * @return array Available cron intervals.
+	 */
+	public function get_intervals() {
+		return $this->core->configs['cron_intervals'];
+	}
+
+	/**
 	 * Check if a scheduler is available.
 	 *
 	 * @since 1.5.1

--- a/admin/class-boldgrid-backup-admin-settings.php
+++ b/admin/class-boldgrid-backup-admin-settings.php
@@ -744,7 +744,8 @@ class Boldgrid_Backup_Admin_Settings {
 			 *
 			 * @since 1.16.0
 			 */
-			if ( isset( $_POST['cron_interval'] ) ) {
+			$intervals_available = $this->core->scheduler->get_intervals();
+			if ( isset( $_POST['cron_interval'] ) && array_key_exists( $_POST['cron_interval'], $intervals_available ) ) {
 				$settings['cron_interval'] = $_POST['cron_interval'];
 			}
 

--- a/admin/partials/settings/scheduler.php
+++ b/admin/partials/settings/scheduler.php
@@ -17,6 +17,7 @@
 defined( 'WPINC' ) || die;
 
 $schedulers_available = $this->core->scheduler->get_available();
+$intervals_available  = $this->core->scheduler->get_intervals();
 $schedulers_count     = count( $schedulers_available );
 $scheduler            = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : false;
 $scheduler_options    = '';
@@ -45,18 +46,11 @@ foreach ( $schedulers_available as $key => $scheduler_data ) {
 
 $scheduler_select = sprintf( '<select name="scheduler" id="scheduler">%1$s</select>', $scheduler_options );
 
-$intervals = array(
-	'*/5 * * * *'  => esc_html__( 'Every 5 Minutes', 'boldgrid-backup' ),
-	'*/10 * * * *' => esc_html__( 'Every 10 Minutes', 'boldgrid-backup' ),
-	'*/30 * * * *' => esc_html__( 'Every 30 Minutes', 'boldgrid-backup' ),
-	'0 * * * *'    => esc_html__( 'Once Every Hour', 'boldgrid-backup' ),
-);
-
 $selected_interval = ! empty( $settings['cron_interval'] ) ? $settings['cron_interval'] : '*/10 * * * *';
 
 $cron_interval_options = '';
 
-foreach ( $intervals as $key => $interval ) {
+foreach ( $intervals_available as $key => $interval ) {
 	$cron_interval_options .= sprintf(
 		'<option value="%1$s" %3$s>%2$s</option>',
 		$key,

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.16.6
+ *          Version: 1.16.7
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/includes/config/config.plugin.php
+++ b/includes/config/config.plugin.php
@@ -127,4 +127,10 @@ return [
 		 */
 		'.ea-php-cli.cache',
 	],
+	'cron_intervals'       => array(
+		'*/5 * * * *'  => esc_html__( 'Every 5 Minutes', 'boldgrid-backup' ),
+		'*/10 * * * *' => esc_html__( 'Every 10 Minutes', 'boldgrid-backup' ),
+		'*/30 * * * *' => esc_html__( 'Every 30 Minutes', 'boldgrid-backup' ),
+		'0 * * * *'    => esc_html__( 'Once Every Hour', 'boldgrid-backup' ),
+	),
 ];

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 5.0
 Tested up to: 6.7
 Requires PHP: 5.4
-Stable tag: 1.16.6
+Stable tag: 1.16.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -131,6 +131,10 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 1. Activate the plugin through the Plugins menu in WordPress.
 
 == Changelog ==
+
+= 1.16.7 =
+Release Date: Nov 11, 2024
+* Bug Fix: Added validation to cron_interval input [#606](https://github.com/BoldGrid/boldgrid-backup/pull/606)
 
 = 1.16.6 =
 Release Date: Nov 7, 2024

--- a/tests/admin/test-class-boldgrid-backup-admin-auto-updates.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-auto-updates.php
@@ -13,6 +13,10 @@
 
 require_once ABSPATH . 'wp-includes/plugin.php';
 require_once ABSPATH . 'wp-admin/includes/class-wp-automatic-updater.php';
+require_once ABSPATH . 'wp-admin/includes/theme.php';
+require_once ABSPATH . 'wp-admin/includes/file.php';
+require_once ABSPATH . 'wp-admin/includes/misc.php';
+require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 require_once dirname( __FILE__ ) . '/class-license.php';
 
 /**
@@ -99,6 +103,15 @@ class Test_Boldgrid_Backup_Admin_Auto_Updates extends WP_UnitTestCase {
 				),
 			),
 		);
+
+		$installed_themes = wp_get_themes();
+		$theme_slug       = 'twentytwentytwo'; // Replace with your desired theme slug
+		$installed        = isset( $installed_themes[$theme_slug] );
+
+		if ( ! $installed ) {
+			$upgrader  = new Theme_Upgrader();
+			$installed = $upgrader->install("https://downloads.wordpress.org/theme/{$theme_slug}.latest-stable.zip");
+		}
 	}
 
 	/**


### PR DESCRIPTION
resolves security notice:
```[WordPress Plugin Directory] Security Notice: Total Upkeep – WordPress Backup Plugin plus Restore & Migrate by BoldGrid

Vulnerability Title: Total Upkeep <= 1.16.5 - Authenticated (Administrator+) Remote Code Execution via Backup Settings
CVE ID: CVE-2024-9461
CVSS Severity Score: 7.2 (High)
CVSS Vector: CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:H/I:H/A:H
Organization: Wordfence
Vulnerability Researcher(s): Jonas Benjamin Friedli

The vulnerable page is the Backup Schedule in the settings. The following request will create a cron tab which is run every minute and creates/updates the file /tmp/poc. Note that the site_check attribute must be set to false (0) and admin access, as well as a nonce is required:

POST /wordpress/wp-admin/admin.php?page=boldgrid-backup-settings HTTP/1.1
cron_interval=*%20*%20*%20*%20*%20%2fusr%2fbin%2ftouch%20%2ftmp%2fpoc%20%26%26&site_check=0&submit=Save+Changes&settings_auth=26daf103b2&save_time=1723968375

The cron-interval resolves to "* * * * * /usr/bin/touch /tmp/poc &&"```