### PR TITLE
Fix scheduled jobs not running, and add extra logging

### DIFF
--- a/admin/class-boldgrid-backup-admin-core.php
+++ b/admin/class-boldgrid-backup-admin-core.php
@@ -741,6 +741,10 @@ class Boldgrid_Backup_Admin_Core {
 
 		$this->remote = new Boldgrid_Backup_Admin_Remote( $this );
 
+		$this->folder_exclusion = new Boldgrid_Backup_Admin_Folder_Exclusion( $this );
+
+		$this->jobs = new Boldgrid_Backup_Admin_Jobs( $this );
+
 		$this->local = new Boldgrid_Backup_Admin_Storage_Local( $this );
 
 		$this->email = new Boldgrid_Backup_Admin_Email( $this );
@@ -752,10 +756,6 @@ class Boldgrid_Backup_Admin_Core {
 		$this->db_get = new Boldgrid_Backup_Admin_Db_get( $this );
 
 		$this->utility = new Boldgrid_Backup_Admin_Utility();
-
-		$this->folder_exclusion = new Boldgrid_Backup_Admin_Folder_Exclusion( $this );
-
-		$this->jobs = new Boldgrid_Backup_Admin_Jobs( $this );
 
 		$this->core_files = new Boldgrid_Backup_Admin_Core_Files( $this );
 

--- a/admin/class-boldgrid-backup-admin-core.php
+++ b/admin/class-boldgrid-backup-admin-core.php
@@ -741,6 +741,7 @@ class Boldgrid_Backup_Admin_Core {
 
 		$this->remote = new Boldgrid_Backup_Admin_Remote( $this );
 
+		// This was moved up the list to ensure it was defined in the Boldgrid_Backup_Admin_Jobs
 		$this->folder_exclusion = new Boldgrid_Backup_Admin_Folder_Exclusion( $this );
 
 		$this->jobs = new Boldgrid_Backup_Admin_Jobs( $this );

--- a/admin/class-boldgrid-backup-admin-core.php
+++ b/admin/class-boldgrid-backup-admin-core.php
@@ -741,8 +741,6 @@ class Boldgrid_Backup_Admin_Core {
 
 		$this->remote = new Boldgrid_Backup_Admin_Remote( $this );
 
-		$this->jobs = new Boldgrid_Backup_Admin_Jobs( $this );
-
 		$this->local = new Boldgrid_Backup_Admin_Storage_Local( $this );
 
 		$this->email = new Boldgrid_Backup_Admin_Email( $this );
@@ -756,6 +754,8 @@ class Boldgrid_Backup_Admin_Core {
 		$this->utility = new Boldgrid_Backup_Admin_Utility();
 
 		$this->folder_exclusion = new Boldgrid_Backup_Admin_Folder_Exclusion( $this );
+
+		$this->jobs = new Boldgrid_Backup_Admin_Jobs( $this );
 
 		$this->core_files = new Boldgrid_Backup_Admin_Core_Files( $this );
 

--- a/admin/class-boldgrid-backup-admin-cron-log.php
+++ b/admin/class-boldgrid-backup-admin-cron-log.php
@@ -139,7 +139,7 @@ class Boldgrid_Backup_Admin_Cron_Log {
 	/**
 	 * Get our scheduled jobs.
 	 *
-	 * @since 1.6.5
+	 * @since 1.17.0
 	 *
 	 * @return string The markup displaying our scheduled jobs.
 	 */
@@ -195,7 +195,7 @@ class Boldgrid_Backup_Admin_Cron_Log {
 	/**
 	 * Generate and return the markup displaying our log entries.
 	 *
-	 * @since 1.17.0
+	 * @since 1.6.5
 	 */
 	public function get_markup() {
 

--- a/admin/class-boldgrid-backup-admin-cron-log.php
+++ b/admin/class-boldgrid-backup-admin-cron-log.php
@@ -195,7 +195,7 @@ class Boldgrid_Backup_Admin_Cron_Log {
 	/**
 	 * Generate and return the markup displaying our log entries.
 	 *
-	 * @since 1.6.5
+	 * @since 1.17.0
 	 */
 	public function get_markup() {
 

--- a/admin/class-boldgrid-backup-admin-cron-log.php
+++ b/admin/class-boldgrid-backup-admin-cron-log.php
@@ -173,6 +173,7 @@ class Boldgrid_Backup_Admin_Cron_Log {
 						<th><strong>%1$s</strong></th>
 						<th><strong>%2$s</strong></th>
 					</tr>
+				</thead>
 				<tbody>',
 			esc_html__( 'Action', 'boldgrid-backup' ),
 			esc_html__( 'Status', 'boldgrid-backup' )

--- a/admin/class-boldgrid-backup-admin-cron-log.php
+++ b/admin/class-boldgrid-backup-admin-cron-log.php
@@ -149,6 +149,17 @@ class Boldgrid_Backup_Admin_Cron_Log {
 			array(),
 		);
 
+		/*
+		 * Filter out any jobs without a 'action_title' key, and add it
+		 * by replacing underscores with spaces and capitalizing each word.
+		 */
+		$jobs = array_map( function( $job ) {
+			if ( ! isset( $job['action_title'] ) ) {
+				$job['action_title'] = ucwords( str_replace( '_', ' ', $job['action'] ) );
+			}
+			return $job;
+		}, $jobs );
+
 		// Return a message if there are no jobs.
 		if ( empty( $jobs ) ) {
 			return '<p style="font-style:italic">' . esc_html__( 'No jobs scheduled.', 'boldgrid-backup' ) . '</p>';

--- a/admin/class-boldgrid-backup-admin-cron-log.php
+++ b/admin/class-boldgrid-backup-admin-cron-log.php
@@ -149,18 +149,12 @@ class Boldgrid_Backup_Admin_Cron_Log {
 			array(),
 		);
 
-		// Filter out any jobs without a 'action_title' and without a 'status' key.
-		$jobs = array_filter(
-			$jobs,
-			function( $job ) {
-				return ! empty( $job['action_title'] ) && ! empty( $job['status'] );
-			}
-		);
-
+		// Return a message if there are no jobs.
 		if ( empty( $jobs ) ) {
 			return '<p style="font-style:italic">' . esc_html__( 'No jobs scheduled.', 'boldgrid-backup' ) . '</p>';
 		}
 
+		// Generate table heading
 		$markup = sprintf(
 			'<table class="wp-list-table widefat striped">
 				<thead>
@@ -173,6 +167,7 @@ class Boldgrid_Backup_Admin_Cron_Log {
 			esc_html__( 'Status', 'boldgrid-backup' )
 		);
 
+		// Generate table rows
 		foreach ( $jobs as $job ) {
 			$title = esc_html( $job['action_title'] );
 			$status = esc_html( ucfirst( $job['status'] ) );

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -191,10 +191,10 @@ class Boldgrid_Backup_Admin_Jobs {
 		}
 
 		$args = array(
-			'filepath'     => $info['filepath'],
-			'action'       => 'boldgrid_backup_post_jobs_email',
-			'action_data'  => $info,
-			'post_action'  => 'delete_all_prior',
+			'filepath'    => $info['filepath'],
+			'action'      => 'boldgrid_backup_post_jobs_email',
+			'action_data' => $info,
+			'post_action' => 'delete_all_prior',
 		);
 
 		$this->add( $args );

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -59,12 +59,13 @@ class Boldgrid_Backup_Admin_Jobs {
 	public $option = 'boldgrid_backup_jobs';
 
 	/**
-	 * 
+	 * Logger
 	 * 
 	 * @since 1.17.0
 	 * 
 	 * @var Boldgrid_Backup_Admin_Log
 	 */
+	public $logger;
 
 	/**
 	 * Constructor.

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -59,6 +59,14 @@ class Boldgrid_Backup_Admin_Jobs {
 	public $option = 'boldgrid_backup_jobs';
 
 	/**
+	 * 
+	 * 
+	 * @since 1.17.0
+	 * 
+	 * @var Boldgrid_Backup_Admin_Log
+	 */
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.5.2
@@ -66,7 +74,9 @@ class Boldgrid_Backup_Admin_Jobs {
 	 * @param Boldgrid_Backup_Admin_Core $core Boldgrid_Backup_Admin_Core Object.
 	 */
 	public function __construct( $core ) {
-		$this->core = $core;
+		$this->core   = $core;
+		$this->logger = new Boldgrid_Backup_Admin_Log( $core );
+		$this->logger->init( 'jobs-queue' );
 	}
 
 	/**
@@ -88,8 +98,7 @@ class Boldgrid_Backup_Admin_Jobs {
 		$this->jobs[] = $args;
 		$this->save_jobs();
 
-		$this->core->logger->init( 'jobs-queue' );
-		$this->core->logger->add( 'Adding Job: ' . json_encode( $args, JSON_PRETTY_PRINT ) );
+		$this->logger->add( 'Adding Job: ' . json_encode( $args, JSON_PRETTY_PRINT ) );
 
 		/*
 		 * The cron entry is removed whenever the cron list is empty,
@@ -127,8 +136,7 @@ class Boldgrid_Backup_Admin_Jobs {
 
 		foreach ( $this->jobs as $key => $job ) {
 			if ( $key <= $delete_key ) {
-				$this->core->logger->init( 'jobs-queue' );
-				$this->core->logger->add( 'Deleting Job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
+				$this->logger->add( 'Deleting Job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
 				unset( $this->jobs[ $key ] );
 			}
 		}
@@ -186,7 +194,6 @@ class Boldgrid_Backup_Admin_Jobs {
 			'action'       => 'boldgrid_backup_post_jobs_email',
 			'action_data'  => $info,
 			'post_action'  => 'delete_all_prior',
-			'action_title' => __( 'Send an email after all jobs have been ran', 'boldgrid-backup' ),
 		);
 
 		$this->add( $args );
@@ -213,8 +220,7 @@ class Boldgrid_Backup_Admin_Jobs {
 		foreach ( $this->jobs as $key => $job ) {
 
 			if ( 'boldgrid_backup_post_jobs_email' === $job['action'] ) {
-				$this->core->logger->init( 'jobs-queue' );
-				$this->core->logger->add( 'Deleting Job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
+				$this->logger->add( 'Deleting Job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
 				unset( $this->jobs[ $key ] );
 				break;
 			}
@@ -330,8 +336,7 @@ class Boldgrid_Backup_Admin_Jobs {
 				continue;
 			}
 
-			$this->core->logger->init( 'jobs-queue' );
-			$this->core->logger->add( 'Running job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
+			$this->logger->add( 'Running job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
 
 			$job['start_time'] = time();
 			$job['status']     = 'running';

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -87,6 +87,21 @@ class Boldgrid_Backup_Admin_Jobs {
 		$this->set_jobs();
 		$this->jobs[] = $args;
 		$this->save_jobs();
+
+		/*
+		 * The cron entry is removed whenever the cron list is empty,
+		 * therefore, when adding a new job, we need to make sure
+		 * we re-add the entry to the crontab. There is no need to check
+		 * if the cron entry already exists, as that is done in the 
+		 * 'schedule_jobs' methods.
+		 */
+		$settings = $this->core->settings->get_settings();
+		$scheduler = $settings['scheduler'];
+		if ( 'cron' === $scheduler ) {
+			$this->core->cron->schedule_jobs( $settings );
+		} elseif ( 'wp-cron' === $scheduler ) {
+			$this->core->wp_cron->schedule_jobs( $settings );
+		}
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -88,6 +88,9 @@ class Boldgrid_Backup_Admin_Jobs {
 		$this->jobs[] = $args;
 		$this->save_jobs();
 
+		$this->core->logger->init( 'jobs-queue' );
+		$this->core->logger->add( 'Adding Job: ' . json_encode( $args, JSON_PRETTY_PRINT ) );
+
 		/*
 		 * The cron entry is removed whenever the cron list is empty,
 		 * therefore, when adding a new job, we need to make sure
@@ -124,6 +127,8 @@ class Boldgrid_Backup_Admin_Jobs {
 
 		foreach ( $this->jobs as $key => $job ) {
 			if ( $key <= $delete_key ) {
+				$this->core->logger->init( 'jobs-queue' );
+				$this->core->logger->add( 'Deleting Job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
 				unset( $this->jobs[ $key ] );
 			}
 		}
@@ -207,6 +212,8 @@ class Boldgrid_Backup_Admin_Jobs {
 		foreach ( $this->jobs as $key => $job ) {
 
 			if ( 'boldgrid_backup_post_jobs_email' === $job['action'] ) {
+				$this->core->logger->init( 'jobs-queue' );
+				$this->core->logger->add( 'Deleting Job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
 				unset( $this->jobs[ $key ] );
 				break;
 			}
@@ -321,6 +328,9 @@ class Boldgrid_Backup_Admin_Jobs {
 			if ( 'pending' !== $job['status'] ) {
 				continue;
 			}
+
+			$this->core->logger->init( 'jobs-queue' );
+			$this->core->logger->add( 'Running job: ' . json_encode( $job, JSON_PRETTY_PRINT ) );
 
 			$job['start_time'] = time();
 			$job['status']     = 'running';

--- a/admin/class-boldgrid-backup-admin-jobs.php
+++ b/admin/class-boldgrid-backup-admin-jobs.php
@@ -182,10 +182,11 @@ class Boldgrid_Backup_Admin_Jobs {
 		}
 
 		$args = array(
-			'filepath'    => $info['filepath'],
-			'action'      => 'boldgrid_backup_post_jobs_email',
-			'action_data' => $info,
-			'post_action' => 'delete_all_prior',
+			'filepath'     => $info['filepath'],
+			'action'       => 'boldgrid_backup_post_jobs_email',
+			'action_data'  => $info,
+			'post_action'  => 'delete_all_prior',
+			'action_title' => __( 'Send an email after all jobs have been ran', 'boldgrid-backup' ),
 		);
 
 		$this->add( $args );


### PR DESCRIPTION
This resolves #612 

The issue turned out to caused by a previous commit: [710cb88](https://github.com/boldgrid/boldgrid-backup/commit/710cb8847d138608d8f9c8990c797a9a1faf7793)

This change was made to remove the cron if there are no scheduled jobs to keep it from running unnecessarily.
However, this didn't account for the fact that when new jobs are added to the list of scheduled jobs, the cron entry
isn't being re-added. This PR will add the cron entry if it doesn't already exist, anytime a job is added to the list of scheduled jobs.

Additionally, I am adding a table to the Total Upkeep > Tools > Cron Log that will display the list of currently scheduled jobs.
![image](https://github.com/user-attachments/assets/b4934047-2d95-41ba-b085-4037eb4f69c5)

As for adding a log entry for anytime the settings are changed, that is already present under Total Upkeep > Tools > History
![image](https://github.com/user-attachments/assets/a9052f24-4e31-41ab-9166-fa980ce87ad5)

Added a `jobs-queue` log file, that logs when a job is added, running, and deleted.
![image](https://github.com/user-attachments/assets/95ef5b1c-8a37-44d7-ae91-bbc742907e82)


