### PR TITLE
fix undefined warning on non getpgid systems

### DIFF
--- a/admin/class-boldgrid-backup-admin-in-progress.php
+++ b/admin/class-boldgrid-backup-admin-in-progress.php
@@ -499,9 +499,10 @@ class Boldgrid_Backup_Admin_In_Progress {
 		 */
 		$response['log'] = esc_html( $log->get_contents() );
 
+		$response['is_running'] = self::is_running();
+
 		// If support is available, add info about whether the backup process is running.
 		if ( Boldgrid_Backup_Admin_Test::is_getpgid_supported() ) {
-			$response['is_running'] = self::is_running();
 			$log->add( 'Backup process running: ' . ( ! $response['is_running'] ? 'No' : 'Yes (pgid = ' . self::getpgid() . ')' ) );
 		}
 


### PR DESCRIPTION
resolves #614 

The warning received in this issue, was caused by the 'is_running' key being defined inside of the `Boldgrid_Backup_Admin_Test::is_getpgid_supported()` conditional. Therefor, systems that do not support getpgid, such as xampp. However, there is no reason that key should be dependant on that condition. Instead, it's been moved to be defined before the condition.

You can test that this resolves the issue by going the the `is_getpgid_supported` method in `admin/class-boldgrid-backup-admin-test.php` and short circuiting the function with a `return false;` statement, and running a backup.