### PR TITLE
ENG7-4653: Rotate stored secrets on upgrade (1.17.4)

### DIFF
--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1550,6 +1550,12 @@ class Boldgrid_Backup_Admin_Cron {
 		$upgraded = false;
 		$settings = $this->core->settings->get_settings( true );
 
+		$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+
+		if ( 'cron' !== $scheduler || ! $this->core->scheduler->is_available( $scheduler ) ) {
+			return false;
+		}
+
 		if ( empty( $settings['crontab_version'] ) ||
 			$this->crontab_version !== $settings['crontab_version'] ) {
 				// Delete and recreate the crontab entries.

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1079,6 +1079,11 @@ class Boldgrid_Backup_Admin_Cron {
 	 * to 1.17.4 this method clears those secrets once, mints a fresh cron_secret, and
 	 * rewrites crontab / restore-info that still embedded the old value.
 	 *
+	 * The one-shot gate is written immediately after remint so a later crontab rewrite
+	 * failure cannot cause another rotation on the next request. Crontab / restore-info
+	 * updates are best-effort; a failed rewrite can be repaired by re-saving settings or
+	 * reactivating the plugin (activation always calls add_all_crons).
+	 *
 	 * @since 1.17.4
 	 *
 	 * @see Boldgrid_Backup_Admin_Cron::get_cron_secret()
@@ -1105,14 +1110,18 @@ class Boldgrid_Backup_Admin_Cron {
 		if ( '' !== $old_secret ) {
 			$new_secret = $this->get_cron_secret();
 
+			/*
+			 * Persist the gate before crontab/restore-info rewrites. Remint already
+			 * invalidated the harvested secret; failing to set the gate here would
+			 * treat the fresh secret as "old" on the next init and rotate forever.
+			 */
+			update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
+
 			$settings  = $this->core->settings->get_settings( true );
 			$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
 
-			$cron_needs_rewrite = 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' );
-			$crons_ok           = true;
-
-			if ( $cron_needs_rewrite ) {
-				$crons_ok = $this->add_all_crons( $settings );
+			if ( 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
+				$this->add_all_crons( $settings );
 			}
 
 			/*
@@ -1131,13 +1140,9 @@ class Boldgrid_Backup_Admin_Cron {
 			}
 
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
-
-			if ( ! $crons_ok ) {
-				return false;
-			}
+		} else {
+			update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
 		}
-
-		update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
 
 		return true;
 	}

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1158,7 +1158,8 @@ class Boldgrid_Backup_Admin_Cron {
 		 * cancel secret without ever having stored a cron_secret, so this cannot be
 		 * limited to the rotation path.
 		 */
-		if ( ( $rotating || $had_cancel_secret ) && get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+		$archives = $this->core->get_archive_list();
+		if ( ( $rotating || $had_cancel_secret ) && get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 			switch ( $scheduler ) {
 				case 'cron':
 					$this->add_restore_cron();

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1088,6 +1088,7 @@ class Boldgrid_Backup_Admin_Cron {
 	 *
 	 * @see Boldgrid_Backup_Admin_Cron::get_cron_secret()
 	 * @see Boldgrid_Backup_Admin_Cron::add_all_crons()
+	 * @see Boldgrid_Backup_Admin_Cron::add_restore_cron()
 	 *
 	 * @return bool True when rotation ran (or was a no-op that set the gate); false if already done.
 	 */
@@ -1098,50 +1099,55 @@ class Boldgrid_Backup_Admin_Cron {
 
 		$settings   = $this->core->settings->get_settings( true );
 		$old_secret = ! empty( $settings['cron_secret'] ) ? (string) $settings['cron_secret'] : '';
+		$new_secret = '';
+		$rotating   = '' !== $old_secret;
 
-		if ( '' !== $old_secret ) {
+		if ( $rotating ) {
 			unset( $settings['cron_secret'] );
 			$this->cron_secret = null;
 			update_site_option( 'boldgrid_backup_settings', $settings );
 		}
 
+		$had_cancel_secret = ! empty( get_site_option( 'boldgrid_backup_cli_cancel_secret' ) );
 		delete_site_option( 'boldgrid_backup_cli_cancel_secret' );
 
-		if ( '' !== $old_secret ) {
+		if ( $rotating ) {
 			$new_secret = $this->get_cron_secret();
+		}
 
-			/*
-			 * Persist the gate before crontab/restore-info rewrites. Remint already
-			 * invalidated the harvested secret; failing to set the gate here would
-			 * treat the fresh secret as "old" on the next init and rotate forever.
-			 */
-			update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
+		/*
+		 * Persist the gate before crontab/restore-info rewrites. Remint already
+		 * invalidated the harvested secret; failing to set the gate here would
+		 * treat the fresh secret as "old" on the next init and rotate forever.
+		 */
+		update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
 
-			$settings  = $this->core->settings->get_settings( true );
-			$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+		$settings  = $this->core->settings->get_settings( true );
+		$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
 
-			if ( 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
-				$this->add_all_crons( $settings );
+		if ( $rotating && 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
+			$this->add_all_crons( $settings );
+		}
+
+		/*
+		 * A pending rollback's restore cron embeds cli_cancel_secret, which was just
+		 * deleted. Re-issue so the emailed cancel link keeps working; a site can hold a
+		 * cancel secret without ever having stored a cron_secret, so this cannot be
+		 * limited to the rotation path.
+		 */
+		if ( ( $rotating || $had_cancel_secret ) && get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+			switch ( $scheduler ) {
+				case 'cron':
+					$this->add_restore_cron();
+					break;
+				case 'wp-cron':
+					$this->core->wp_cron->add_restore_cron();
+					break;
 			}
+		}
 
-			/*
-			 * Pending auto-rollback restore crons embed cli_cancel_secret. Re-issue so
-			 * cancel still works for an in-flight rollback after the option was cleared.
-			 */
-			if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
-				switch ( $scheduler ) {
-					case 'cron':
-						$this->add_restore_cron();
-						break;
-					case 'wp-cron':
-						$this->core->wp_cron->add_restore_cron();
-						break;
-				}
-			}
-
+		if ( $rotating ) {
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
-		} else {
-			update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
 		}
 
 		return true;

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1143,7 +1143,9 @@ class Boldgrid_Backup_Admin_Cron {
 	 * updates are best-effort; a failed rewrite can be repaired by re-saving settings or
 	 * reactivating the plugin (activation always calls add_all_crons). Concurrent
 	 * requests are serialized by a claim, since two remints would leave crontab and
-	 * settings holding different secrets.
+	 * settings holding different secrets. Abandoned-claim takeover remints even when
+	 * settings already lost the old secret, and refreshes restore-info without requiring
+	 * that prior value.
 	 *
 	 * @since 1.17.4
 	 *
@@ -1232,7 +1234,12 @@ class Boldgrid_Backup_Admin_Cron {
 			}
 		}
 
-		if ( '' !== $old_secret && '' !== $new_secret ) {
+		/*
+		 * Normal rotation knows the harvested secret from settings. On takeover the prior
+		 * request may already have deleted it, so refresh with an empty $old_secret to rewrite
+		 * any restore-info still holding a different value.
+		 */
+		if ( '' !== $new_secret && ( '' !== $old_secret || $is_takeover ) ) {
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
 		}
 
@@ -1281,9 +1288,13 @@ class Boldgrid_Backup_Admin_Cron {
 	 * legacy plugin cron/ directory is rewritten only when it is still the live metadata
 	 * (no secure storage), and otherwise has its retired copies deleted.
 	 *
+	 * When $old_secret is empty (abandoned-claim takeover), any file whose cron_secret
+	 * is not already $new_secret is rewritten, since settings no longer hold the prior
+	 * value to match against.
+	 *
 	 * @since 1.17.4
 	 *
-	 * @param string $old_secret Prior cron secret.
+	 * @param string $old_secret Prior cron secret, or empty to rewrite any non-matching file.
 	 * @param string $new_secret Fresh cron secret.
 	 * @return bool True when a restore-info file was updated.
 	 */
@@ -1291,7 +1302,7 @@ class Boldgrid_Backup_Admin_Cron {
 		$old_secret = (string) $old_secret;
 		$new_secret = (string) $new_secret;
 
-		if ( '' === $old_secret || '' === $new_secret || hash_equals( $old_secret, $new_secret ) ) {
+		if ( '' === $new_secret || ( '' !== $old_secret && hash_equals( $old_secret, $new_secret ) ) ) {
 			return false;
 		}
 
@@ -1321,7 +1332,7 @@ class Boldgrid_Backup_Admin_Cron {
 		$legacy_paths = $this->get_restore_info_paths( BOLDGRID_BACKUP_PATH . '/cron' );
 
 		if ( \Boldgrid\Backup\Cli\Info::get_secure_storage_dir() ) {
-			$this->delete_stale_restore_info( $legacy_paths, $old_secret );
+			$this->delete_stale_restore_info( $legacy_paths, $old_secret, $new_secret );
 		} else {
 			$paths = array_merge( $paths, $legacy_paths );
 		}
@@ -1335,7 +1346,13 @@ class Boldgrid_Backup_Admin_Cron {
 				continue;
 			}
 
-			if ( ! hash_equals( (string) $data['cron_secret'], $old_secret ) ) {
+			$file_secret = (string) $data['cron_secret'];
+
+			if ( '' !== $old_secret ) {
+				if ( ! hash_equals( $file_secret, $old_secret ) ) {
+					continue;
+				}
+			} elseif ( hash_equals( $file_secret, $new_secret ) ) {
 				continue;
 			}
 
@@ -1343,7 +1360,7 @@ class Boldgrid_Backup_Admin_Cron {
 
 			if ( ! empty( $data['restore_cmd'] ) && is_string( $data['restore_cmd'] ) ) {
 				$data['restore_cmd'] = str_replace(
-					'secret=' . $old_secret,
+					'secret=' . $file_secret,
 					'secret=' . $new_secret,
 					$data['restore_cmd']
 				);
@@ -1402,16 +1419,21 @@ class Boldgrid_Backup_Admin_Cron {
 	 * Delete restore-info copies that still hold a rotated-out cron secret.
 	 *
 	 * Used for copies the CLI can no longer reach, so the retired secret does not linger
-	 * on disk. Files holding any other secret are left alone.
+	 * on disk. Files holding any other secret are left alone, unless $old_secret is empty
+	 * (takeover recovery) in which case any file whose cron_secret is not $new_secret is
+	 * removed.
 	 *
 	 * @since 1.17.4
 	 *
 	 * @param  array  $paths      Restore-info paths to consider.
-	 * @param  string $old_secret Rotated-out cron secret.
+	 * @param  string $old_secret Rotated-out cron secret, or empty for takeover recovery.
+	 * @param  string $new_secret Fresh cron secret (used when $old_secret is empty).
 	 * @return int Number of files deleted.
 	 */
-	private function delete_stale_restore_info( array $paths, $old_secret ) {
-		$deleted = 0;
+	private function delete_stale_restore_info( array $paths, $old_secret, $new_secret = '' ) {
+		$deleted    = 0;
+		$old_secret = (string) $old_secret;
+		$new_secret = (string) $new_secret;
 
 		foreach ( $paths as $path ) {
 			$data = $this->read_restore_info( $path );
@@ -1419,7 +1441,13 @@ class Boldgrid_Backup_Admin_Cron {
 				continue;
 			}
 
-			if ( ! hash_equals( (string) $data['cron_secret'], (string) $old_secret ) ) {
+			$file_secret = (string) $data['cron_secret'];
+
+			if ( '' !== $old_secret ) {
+				if ( ! hash_equals( $file_secret, $old_secret ) ) {
+					continue;
+				}
+			} elseif ( '' === $new_secret || hash_equals( $file_secret, $new_secret ) ) {
 				continue;
 			}
 

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -376,7 +376,7 @@ class Boldgrid_Backup_Admin_Cron {
 	 * @return bool True if an active direct transfer exists.
 	 */
 	public function has_active_direct_transfer() {
-		$config       = $this->core->configs['direct_transfer'];
+		$config       = ! empty( $this->core->configs['direct_transfer'] ) ? $this->core->configs['direct_transfer'] : array();
 		$option_names = ! empty( $config['option_names'] ) ? $config['option_names'] : array();
 
 		$active_rx = ! empty( $option_names['active_transfer'] )
@@ -394,9 +394,16 @@ class Boldgrid_Backup_Admin_Cron {
 		$transfers_option = ! empty( $option_names['transfers'] ) ? $option_names['transfers'] : '';
 		$transfers        = '' !== $transfers_option ? get_option( $transfers_option, array() ) : array();
 
-		if ( ! empty( $active_rx ) ) {
-			if ( isset( $transfers[ $active_rx ] ) &&
-				! in_array( $transfers[ $active_rx ]['status'], array( 'completed', 'cancelled' ), true ) ) {
+		/*
+		 * Migrate writes "canceled"; some call sites historically checked "cancelled".
+		 * Treat both (and other terminal statuses) as inactive. Missing status is treated
+		 * as active so a corrupted option cannot drop an in-progress transfer cron.
+		 */
+		$inactive_statuses = array( 'completed', 'restore-completed', 'failed', 'canceled', 'cancelled' );
+
+		if ( ! empty( $active_rx ) && isset( $transfers[ $active_rx ] ) && is_array( $transfers[ $active_rx ] ) ) {
+			$status = isset( $transfers[ $active_rx ]['status'] ) ? $transfers[ $active_rx ]['status'] : '';
+			if ( ! in_array( $status, $inactive_statuses, true ) ) {
 				return true;
 			}
 		}
@@ -1204,15 +1211,18 @@ class Boldgrid_Backup_Admin_Cron {
 
 		if ( $rotating && 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
 			$this->add_all_crons( $settings );
+		}
 
-			/*
-			 * add_all_crons clears all crontab entries but does not recreate direct-transfer
-			 * schedules, which are managed separately. If an active transfer exists, reschedule
-			 * its cron so the transfer continues under the new secret.
-			 */
-			if ( $this->has_active_direct_transfer() ) {
-				$this->schedule_direct_transfer();
-			}
+		/*
+		 * Direct transfer always uses system crontab with an embedded cron_secret, even when
+		 * the configured backup scheduler is wp-cron. add_all_crons (system-cron path) clears
+		 * that entry and never recreates it; the wp-cron path never touches it, so the old
+		 * secret would keep working against settings that no longer accept it. Delete then
+		 * reschedule so only the new secret remains.
+		 */
+		if ( $rotating && $this->has_active_direct_transfer() ) {
+			$this->entry_delete_contains( 'direct-transfer.php' );
+			$this->schedule_direct_transfer();
 		}
 
 		/*

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -366,6 +366,49 @@ class Boldgrid_Backup_Admin_Cron {
 	}
 
 	/**
+	 * Check if there is an active direct transfer in progress.
+	 *
+	 * Direct transfers can be active on either the receiving side (active_transfer)
+	 * or the sending side (active_tx). This checks both.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @return bool True if an active direct transfer exists.
+	 */
+	public function has_active_direct_transfer() {
+		$config       = $this->core->configs['direct_transfer'];
+		$option_names = ! empty( $config['option_names'] ) ? $config['option_names'] : array();
+
+		$active_rx = ! empty( $option_names['active_transfer'] )
+			? get_option( $option_names['active_transfer'], false )
+			: false;
+
+		$active_tx = ! empty( $option_names['active_tx'] )
+			? get_option( $option_names['active_tx'], false )
+			: false;
+
+		if ( empty( $active_rx ) && empty( $active_tx ) ) {
+			return false;
+		}
+
+		$transfers_option = ! empty( $option_names['transfers'] ) ? $option_names['transfers'] : '';
+		$transfers        = '' !== $transfers_option ? get_option( $transfers_option, array() ) : array();
+
+		if ( ! empty( $active_rx ) ) {
+			if ( isset( $transfers[ $active_rx ] ) &&
+				! in_array( $transfers[ $active_rx ]['status'], array( 'completed', 'cancelled' ), true ) ) {
+				return true;
+			}
+		}
+
+		if ( ! empty( $active_tx ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Schedule Site Check.
 	 *
 	 * This method is usually ran after saving the settings. If (after save) cron is our scheduler,
@@ -1159,6 +1202,15 @@ class Boldgrid_Backup_Admin_Cron {
 
 		if ( $rotating && 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
 			$this->add_all_crons( $settings );
+
+			/*
+			 * add_all_crons clears all crontab entries but does not recreate direct-transfer
+			 * schedules, which are managed separately. If an active transfer exists, reschedule
+			 * its cron so the transfer continues under the new secret.
+			 */
+			if ( $this->has_active_direct_transfer() ) {
+				$this->schedule_direct_transfer();
+			}
 		}
 
 		/*

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1555,6 +1555,22 @@ class Boldgrid_Backup_Admin_Cron {
 				// Delete and recreate the crontab entries.
 				$upgraded = $this->add_all_crons( $settings );
 
+			/*
+			 * add_all_crons clears all BoldGrid crontab entries and only re-adds
+			 * backup/jobs/site-check. Pending rollback restore crons and active
+			 * direct-transfer crons must be re-added afterward, regardless of
+			 * whether add_all_crons succeeded, to avoid dropping critical jobs.
+			 */
+			$archives = $this->core->get_archive_list();
+			if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
+				$this->add_restore_cron();
+			}
+
+			if ( $this->has_active_direct_transfer() ) {
+				$this->entry_delete_contains( 'direct-transfer.php' );
+				$this->schedule_direct_transfer();
+			}
+
 			if ( $upgraded ) {
 				/**
 					 * Action when the crontab entry upgrade is successfully completed.

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1116,16 +1116,25 @@ class Boldgrid_Backup_Admin_Cron {
 			return false;
 		}
 
-		if ( ! $this->claim_secrets_rotation() ) {
+		$claim_result = $this->claim_secrets_rotation();
+		if ( false === $claim_result ) {
 			return false;
 		}
+
+		/*
+		 * When taking over an abandoned claim, the failed request may have already
+		 * deleted cron_secret and cli_cancel_secret before dying. In that case
+		 * $old_secret would be empty and we would skip remint/rewrite, leaving
+		 * crontab broken. Force a full rotation on takeover to ensure recovery.
+		 */
+		$is_takeover = 'takeover' === $claim_result;
 
 		$settings   = $this->core->settings->get_settings( true );
 		$old_secret = ! empty( $settings['cron_secret'] ) ? (string) $settings['cron_secret'] : '';
 		$new_secret = '';
-		$rotating   = '' !== $old_secret;
+		$rotating   = '' !== $old_secret || $is_takeover;
 
-		if ( $rotating ) {
+		if ( '' !== $old_secret ) {
 			unset( $settings['cron_secret'] );
 			$this->cron_secret = null;
 			update_site_option( 'boldgrid_backup_settings', $settings );
@@ -1156,10 +1165,11 @@ class Boldgrid_Backup_Admin_Cron {
 		 * A pending rollback's restore cron embeds cli_cancel_secret, which was just
 		 * deleted. Re-issue so the emailed cancel link keeps working; a site can hold a
 		 * cancel secret without ever having stored a cron_secret, so this cannot be
-		 * limited to the rotation path.
+		 * limited to the rotation path. On takeover, always re-issue since the
+		 * failed request may have already deleted cli_cancel_secret.
 		 */
 		$archives = $this->core->get_archive_list();
-		if ( ( $rotating || $had_cancel_secret ) && get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
+		if ( ( $rotating || $had_cancel_secret || $is_takeover ) && get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 			switch ( $scheduler ) {
 				case 'cron':
 					$this->add_restore_cron();
@@ -1170,7 +1180,7 @@ class Boldgrid_Backup_Admin_Cron {
 			}
 		}
 
-		if ( $rotating ) {
+		if ( '' !== $old_secret && '' !== $new_secret ) {
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
 		}
 
@@ -1191,11 +1201,12 @@ class Boldgrid_Backup_Admin_Cron {
 	 *
 	 * @since 1.17.4
 	 *
-	 * @return bool True when this request owns the rotation.
+	 * @return string|false 'fresh' when this request is the first claimer, 'takeover' when
+	 *                      claiming an abandoned rotation, false when another request owns it.
 	 */
 	private function claim_secrets_rotation() {
 		if ( add_site_option( self::SECRETS_ROTATING_OPTION, time() ) ) {
-			return true;
+			return 'fresh';
 		}
 
 		$claimed_at = (int) get_site_option( self::SECRETS_ROTATING_OPTION );
@@ -1206,7 +1217,7 @@ class Boldgrid_Backup_Admin_Cron {
 
 		update_site_option( self::SECRETS_ROTATING_OPTION, time() );
 
-		return true;
+		return 'takeover';
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1031,6 +1031,22 @@ class Boldgrid_Backup_Admin_Cron {
 	}
 
 	/**
+	 * Site option key for the one-time secrets rotation gate.
+	 *
+	 * @since 1.17.4
+	 * @var string
+	 */
+	const SECRETS_ROTATED_OPTION = 'boldgrid_backup_secrets_rotated';
+
+	/**
+	 * Plugin version that introduced one-time cron/CLI secret rotation.
+	 *
+	 * @since 1.17.4
+	 * @var string
+	 */
+	const SECRETS_ROTATED_VERSION = '1.17.4';
+
+	/**
 	 * Get the cron secret used to validate unauthenticated crontab jobs.
 	 *
 	 * @since 1.6.1-rc.1
@@ -1053,6 +1069,166 @@ class Boldgrid_Backup_Admin_Cron {
 		}
 
 		return $this->cron_secret;
+	}
+
+	/**
+	 * One-time rotation of previously exposable cron / CLI cancel secrets.
+	 *
+	 * Sites that ran 1.14.10–1.17.2 may have had cron_secret published at a predictable
+	 * URL. 1.17.3 stopped the leak but left any already-stored secret valid. On upgrade
+	 * to 1.17.4 this method clears those secrets once, mints a fresh cron_secret, and
+	 * rewrites crontab / restore-info that still embedded the old value.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @see Boldgrid_Backup_Admin_Cron::get_cron_secret()
+	 * @see Boldgrid_Backup_Admin_Cron::add_all_crons()
+	 *
+	 * @return bool True when rotation ran (or was a no-op that set the gate); false if already done.
+	 */
+	public function maybe_rotate_cron_secrets() {
+		if ( self::SECRETS_ROTATED_VERSION === get_site_option( self::SECRETS_ROTATED_OPTION ) ) {
+			return false;
+		}
+
+		$settings   = $this->core->settings->get_settings( true );
+		$old_secret = ! empty( $settings['cron_secret'] ) ? (string) $settings['cron_secret'] : '';
+
+		if ( '' !== $old_secret ) {
+			unset( $settings['cron_secret'] );
+			$this->cron_secret = null;
+			update_site_option( 'boldgrid_backup_settings', $settings );
+		}
+
+		delete_site_option( 'boldgrid_backup_cli_cancel_secret' );
+
+		if ( '' !== $old_secret ) {
+			$new_secret = $this->get_cron_secret();
+
+			$settings  = $this->core->settings->get_settings( true );
+			$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+
+			if ( 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
+				$this->add_all_crons( $settings );
+			}
+
+			/*
+			 * Pending auto-rollback restore crons embed cli_cancel_secret. Re-issue so
+			 * cancel still works for an in-flight rollback after the option was cleared.
+			 */
+			if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+				$this->add_restore_cron();
+			}
+
+			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
+		}
+
+		update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
+
+		return true;
+	}
+
+	/**
+	 * Rewrite cron_secret inside the secure restore-info JSON after rotation.
+	 *
+	 * Emergency CLI restore builds its admin-ajax call from this file. Leaving the
+	 * old secret would either fail is_valid_call() or (worse) leave a harvested value
+	 * as the only copy trusted by the CLI path.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @param string $old_secret Prior cron secret.
+	 * @param string $new_secret Fresh cron secret.
+	 * @return bool True when a restore-info file was updated.
+	 */
+	public function refresh_restore_info_cron_secret( $old_secret, $new_secret ) {
+		$old_secret = (string) $old_secret;
+		$new_secret = (string) $new_secret;
+
+		if ( '' === $old_secret || '' === $new_secret || hash_equals( $old_secret, $new_secret ) ) {
+			return false;
+		}
+
+		$backup_dir = $this->core->backup_dir->get();
+		if ( empty( $backup_dir ) ) {
+			return false;
+		}
+
+		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
+
+		$backup_dir = \Boldgrid\Backup\Cli\Info::untrailingslashit_path( (string) $backup_dir );
+		$paths      = array();
+
+		$cli_secret = \Boldgrid\Backup\Cli\Info::get_secret();
+		if ( \Boldgrid\Backup\Cli\Info::is_valid_secret_format( $cli_secret ) ) {
+			$paths[] = \Boldgrid\Backup\Cli\Info::trailingslashit_path( $backup_dir ) .
+				'restore-info-' . $cli_secret . '.json';
+		}
+
+		// Also scan for any restore-info-*.json in the backup directory (orphan names).
+		$listing = @scandir( $backup_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( ! empty( $listing ) ) {
+			foreach ( preg_grep( '/^restore-info-.*\.json$/', $listing ) as $file ) {
+				$paths[] = $backup_dir . '/' . $file;
+			}
+		}
+
+		$paths   = array_unique( $paths );
+		$updated = false;
+
+		foreach ( $paths as $path ) {
+			if ( ! is_readable( $path ) ) {
+				continue;
+			}
+
+			$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			if ( false === $contents ) {
+				continue;
+			}
+
+			$data = json_decode( $contents, true );
+			if ( ! is_array( $data ) || empty( $data['cron_secret'] ) ) {
+				continue;
+			}
+
+			if ( ! hash_equals( (string) $data['cron_secret'], $old_secret ) ) {
+				continue;
+			}
+
+			$data['cron_secret'] = $new_secret;
+
+			if ( ! empty( $data['restore_cmd'] ) && is_string( $data['restore_cmd'] ) ) {
+				$data['restore_cmd'] = str_replace(
+					'secret=' . $old_secret,
+					'secret=' . $new_secret,
+					$data['restore_cmd']
+				);
+			}
+
+			$payload = wp_json_encode( $data );
+			if ( false === $payload ) {
+				continue;
+			}
+
+			$written = false;
+			if ( ! empty( $this->core->wp_filesystem ) ) {
+				$written = (bool) $this->core->wp_filesystem->put_contents( $path, $payload, 0600 );
+			}
+
+			if ( ! $written ) {
+				$bytes = @file_put_contents( $path, $payload ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+				if ( false !== $bytes ) {
+					@chmod( $path, 0600 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					$written = true;
+				}
+			}
+
+			if ( $written ) {
+				$updated = true;
+			}
+		}
+
+		return $updated;
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1108,8 +1108,11 @@ class Boldgrid_Backup_Admin_Cron {
 			$settings  = $this->core->settings->get_settings( true );
 			$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
 
-			if ( 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
-				$this->add_all_crons( $settings );
+			$cron_needs_rewrite = 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' );
+			$crons_ok           = true;
+
+			if ( $cron_needs_rewrite ) {
+				$crons_ok = $this->add_all_crons( $settings );
 			}
 
 			/*
@@ -1128,6 +1131,10 @@ class Boldgrid_Backup_Admin_Cron {
 			}
 
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
+
+			if ( ! $crons_ok ) {
+				return false;
+			}
 		}
 
 		update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1047,6 +1047,22 @@ class Boldgrid_Backup_Admin_Cron {
 	const SECRETS_ROTATED_VERSION = '1.17.4';
 
 	/**
+	 * Site option key used to claim an in-progress secrets rotation.
+	 *
+	 * @since 1.17.4
+	 * @var string
+	 */
+	const SECRETS_ROTATING_OPTION = 'boldgrid_backup_secrets_rotating';
+
+	/**
+	 * Seconds after which an abandoned rotation claim may be taken over.
+	 *
+	 * @since 1.17.4
+	 * @var int
+	 */
+	const SECRETS_ROTATING_TIMEOUT = 300;
+
+	/**
 	 * Get the cron secret used to validate unauthenticated crontab jobs.
 	 *
 	 * @since 1.6.1-rc.1
@@ -1082,10 +1098,13 @@ class Boldgrid_Backup_Admin_Cron {
 	 * The one-shot gate is written immediately after remint so a later crontab rewrite
 	 * failure cannot cause another rotation on the next request. Crontab / restore-info
 	 * updates are best-effort; a failed rewrite can be repaired by re-saving settings or
-	 * reactivating the plugin (activation always calls add_all_crons).
+	 * reactivating the plugin (activation always calls add_all_crons). Concurrent
+	 * requests are serialized by a claim, since two remints would leave crontab and
+	 * settings holding different secrets.
 	 *
 	 * @since 1.17.4
 	 *
+	 * @see Boldgrid_Backup_Admin_Cron::claim_secrets_rotation()
 	 * @see Boldgrid_Backup_Admin_Cron::get_cron_secret()
 	 * @see Boldgrid_Backup_Admin_Cron::add_all_crons()
 	 * @see Boldgrid_Backup_Admin_Cron::add_restore_cron()
@@ -1094,6 +1113,10 @@ class Boldgrid_Backup_Admin_Cron {
 	 */
 	public function maybe_rotate_cron_secrets() {
 		if ( self::SECRETS_ROTATED_VERSION === get_site_option( self::SECRETS_ROTATED_OPTION ) ) {
+			return false;
+		}
+
+		if ( ! $this->claim_secrets_rotation() ) {
 			return false;
 		}
 
@@ -1150,6 +1173,38 @@ class Boldgrid_Backup_Admin_Cron {
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );
 		}
 
+		delete_site_option( self::SECRETS_ROTATING_OPTION );
+
+		return true;
+	}
+
+	/**
+	 * Claim the one-time rotation so concurrent requests do not both remint.
+	 *
+	 * Two requests can pass the gate check before either persists it, which would remint
+	 * twice and leave crontab and settings holding different secrets. add_site_option()
+	 * only reports success for the request that inserts the row, so it serializes the
+	 * common case. A claim older than SECRETS_ROTATING_TIMEOUT is assumed abandoned by a
+	 * request that died mid-rotation and may be taken over, otherwise a fatal during
+	 * rotation would block the upgrade permanently.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @return bool True when this request owns the rotation.
+	 */
+	private function claim_secrets_rotation() {
+		if ( add_site_option( self::SECRETS_ROTATING_OPTION, time() ) ) {
+			return true;
+		}
+
+		$claimed_at = (int) get_site_option( self::SECRETS_ROTATING_OPTION );
+
+		if ( $claimed_at && ( time() - $claimed_at ) < self::SECRETS_ROTATING_TIMEOUT ) {
+			return false;
+		}
+
+		update_site_option( self::SECRETS_ROTATING_OPTION, time() );
+
 		return true;
 	}
 
@@ -1158,7 +1213,9 @@ class Boldgrid_Backup_Admin_Cron {
 	 *
 	 * Emergency CLI restore builds its admin-ajax call from this file. Leaving the
 	 * old secret would either fail is_valid_call() or (worse) leave a harvested value
-	 * as the only copy trusted by the CLI path.
+	 * as the only copy trusted by the CLI path. Secure storage is always scanned; the
+	 * legacy plugin cron/ directory is rewritten only when it is still the live metadata
+	 * (no secure storage), and otherwise has its retired copies deleted.
 	 *
 	 * @since 1.17.4
 	 *
@@ -1174,45 +1231,43 @@ class Boldgrid_Backup_Admin_Cron {
 			return false;
 		}
 
-		$backup_dir = $this->core->backup_dir->get();
-		if ( empty( $backup_dir ) ) {
-			return false;
-		}
-
 		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
 
-		$backup_dir = \Boldgrid\Backup\Cli\Info::untrailingslashit_path( (string) $backup_dir );
 		$paths      = array();
+		$backup_dir = $this->core->backup_dir->get();
 
-		$cli_secret = \Boldgrid\Backup\Cli\Info::get_secret();
-		if ( \Boldgrid\Backup\Cli\Info::is_valid_secret_format( $cli_secret ) ) {
-			$paths[] = \Boldgrid\Backup\Cli\Info::trailingslashit_path( $backup_dir ) .
-				'restore-info-' . $cli_secret . '.json';
+		if ( ! empty( $backup_dir ) ) {
+			$backup_dir = \Boldgrid\Backup\Cli\Info::untrailingslashit_path( (string) $backup_dir );
+
+			$cli_secret = \Boldgrid\Backup\Cli\Info::get_secret();
+			if ( \Boldgrid\Backup\Cli\Info::is_valid_secret_format( $cli_secret ) ) {
+				$paths[] = $backup_dir . '/restore-info-' . $cli_secret . '.json';
+			}
+
+			// Also scan for any restore-info-*.json in the backup directory (orphan names).
+			$paths = array_merge( $paths, $this->get_restore_info_paths( $backup_dir ) );
 		}
 
-		// Also scan for any restore-info-*.json in the backup directory (orphan names).
-		$listing = @scandir( $backup_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
-		if ( ! empty( $listing ) ) {
-			foreach ( preg_grep( '/^restore-info-.*\.json$/', $listing ) as $file ) {
-				$paths[] = $backup_dir . '/' . $file;
-			}
+		/*
+		 * The CLI only reads the legacy plugin-tree copy when secure storage is
+		 * unavailable, and the plugin tree is not a guaranteed-private location. Rewrite
+		 * it only while it is the live metadata; otherwise the CLI cannot reach it, so
+		 * delete it instead of storing a fresh secret there.
+		 */
+		$legacy_paths = $this->get_restore_info_paths( BOLDGRID_BACKUP_PATH . '/cron' );
+
+		if ( \Boldgrid\Backup\Cli\Info::get_secure_storage_dir() ) {
+			$this->delete_stale_restore_info( $legacy_paths, $old_secret );
+		} else {
+			$paths = array_merge( $paths, $legacy_paths );
 		}
 
 		$paths   = array_unique( $paths );
 		$updated = false;
 
 		foreach ( $paths as $path ) {
-			if ( ! is_readable( $path ) ) {
-				continue;
-			}
-
-			$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			if ( false === $contents ) {
-				continue;
-			}
-
-			$data = json_decode( $contents, true );
-			if ( ! is_array( $data ) || empty( $data['cron_secret'] ) ) {
+			$data = $this->read_restore_info( $path );
+			if ( null === $data || empty( $data['cron_secret'] ) ) {
 				continue;
 			}
 
@@ -1243,7 +1298,7 @@ class Boldgrid_Backup_Admin_Cron {
 			if ( ! $written ) {
 				$bytes = @file_put_contents( $path, $payload ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 				if ( false !== $bytes ) {
-					@chmod( $path, 0600 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					@chmod( $path, 0600 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_operations_chmod
 					$written = true;
 				}
 			}
@@ -1254,6 +1309,90 @@ class Boldgrid_Backup_Admin_Cron {
 		}
 
 		return $updated;
+	}
+
+	/**
+	 * Read and decode a restore-info JSON file.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @param  string $path Absolute path to a restore-info file.
+	 * @return array|null Decoded data, or null when unreadable / not JSON.
+	 */
+	private function read_restore_info( $path ) {
+		if ( ! is_readable( $path ) ) {
+			return null;
+		}
+
+		$contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		if ( false === $contents ) {
+			return null;
+		}
+
+		$data = json_decode( $contents, true );
+
+		return is_array( $data ) ? $data : null;
+	}
+
+	/**
+	 * Delete restore-info copies that still hold a rotated-out cron secret.
+	 *
+	 * Used for copies the CLI can no longer reach, so the retired secret does not linger
+	 * on disk. Files holding any other secret are left alone.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @param  array  $paths      Restore-info paths to consider.
+	 * @param  string $old_secret Rotated-out cron secret.
+	 * @return int Number of files deleted.
+	 */
+	private function delete_stale_restore_info( array $paths, $old_secret ) {
+		$deleted = 0;
+
+		foreach ( $paths as $path ) {
+			$data = $this->read_restore_info( $path );
+			if ( null === $data || empty( $data['cron_secret'] ) ) {
+				continue;
+			}
+
+			if ( ! hash_equals( (string) $data['cron_secret'], (string) $old_secret ) ) {
+				continue;
+			}
+
+			if ( @unlink( $path ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.unlink_unlink
+				++$deleted;
+			}
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * List restore-info-*.json files in a directory.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @param  string $dir Directory to scan.
+	 * @return array Absolute paths, empty when the directory is unreadable.
+	 */
+	private function get_restore_info_paths( $dir ) {
+		$dir   = \Boldgrid\Backup\Cli\Info::untrailingslashit_path( (string) $dir );
+		$paths = array();
+
+		if ( '' === $dir || ! is_dir( $dir ) ) {
+			return $paths;
+		}
+
+		$listing = @scandir( $dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+		if ( empty( $listing ) ) {
+			return $paths;
+		}
+
+		foreach ( preg_grep( '/^restore-info-.*\.json$/', $listing ) as $file ) {
+			$paths[] = $dir . '/' . $file;
+		}
+
+		return $paths;
 	}
 
 	/**

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1117,7 +1117,14 @@ class Boldgrid_Backup_Admin_Cron {
 			 * cancel still works for an in-flight rollback after the option was cleared.
 			 */
 			if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
-				$this->add_restore_cron();
+				switch ( $scheduler ) {
+					case 'cron':
+						$this->add_restore_cron();
+						break;
+					case 'wp-cron':
+						$this->core->wp_cron->add_restore_cron();
+						break;
+				}
 			}
 
 			$this->refresh_restore_info_cron_secret( $old_secret, $new_secret );

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1213,7 +1213,7 @@ class Boldgrid_Backup_Admin_Cron {
 		update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
 
 		$settings  = $this->core->settings->get_settings( true );
-		$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+		$scheduler = $this->core->scheduler->get();
 
 		if ( $rotating && 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
 			$this->add_all_crons( $settings );

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -1274,7 +1274,17 @@ class Boldgrid_Backup_Admin_Cron {
 			return false;
 		}
 
-		update_site_option( self::SECRETS_ROTATING_OPTION, time() );
+		/*
+		 * Delete the stale claim and re-add atomically. add_site_option() only succeeds
+		 * for the first inserter, so concurrent takeover attempts are serialized the
+		 * same way fresh claims are. If another request wins the race, fall back to
+		 * waiting for it to complete.
+		 */
+		delete_site_option( self::SECRETS_ROTATING_OPTION );
+
+		if ( ! add_site_option( self::SECRETS_ROTATING_OPTION, time() ) ) {
+			return false;
+		}
 
 		return 'takeover';
 	}

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -218,7 +218,13 @@ class Boldgrid_Backup_Admin_Cron {
 			$jobs_scheduled = $this->schedule_jobs( $settings );
 			$site_check     = $this->schedule_site_check( $settings );
 
-			$success = $scheduled && $jobs_scheduled;
+			/*
+			 * An empty schedule is success when jobs were written: there is no backup
+			 * entry to add. Requiring $scheduled here left crontab_version unset, so
+			 * upgrade_crontab_entries cleared restore/direct-transfer jobs on every
+			 * admin_init for sites with no backup schedule.
+			 */
+			$success = ( empty( $schedule ) || $scheduled ) && $jobs_scheduled;
 
 			if ( $success ) {
 				$settings['crontab_version'] = $this->crontab_version;
@@ -1558,14 +1564,16 @@ class Boldgrid_Backup_Admin_Cron {
 
 		if ( empty( $settings['crontab_version'] ) ||
 			$this->crontab_version !== $settings['crontab_version'] ) {
-				// Delete and recreate the crontab entries.
-				$upgraded = $this->add_all_crons( $settings );
+			// Delete and recreate the crontab entries.
+			$upgraded = $this->add_all_crons( $settings );
 
 			/*
 			 * add_all_crons clears all BoldGrid crontab entries and only re-adds
 			 * backup/jobs/site-check. Pending rollback restore crons and active
-			 * direct-transfer crons must be re-added afterward, regardless of
-			 * whether add_all_crons succeeded, to avoid dropping critical jobs.
+			 * direct-transfer crons must be re-added afterward — matching activation
+			 * and secret rotation. When the schedule is empty, add_all_crons may
+			 * return false without persisting crontab_version; without this follow-up
+			 * those jobs would be dropped again on every admin_init.
 			 */
 			$archives = $this->core->get_archive_list();
 			if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
@@ -1579,12 +1587,12 @@ class Boldgrid_Backup_Admin_Cron {
 
 			if ( $upgraded ) {
 				/**
-					 * Action when the crontab entry upgrade is successfully completed.
-					 *
-					 * @since 1.6.1-rc.1
-					 *
-					 * @param string The new crontab entry version.
-					 */
+				 * Action when the crontab entry upgrade is successfully completed.
+				 *
+				 * @since 1.6.1-rc.1
+				 *
+				 * @param string The new crontab entry version.
+				 */
 				do_action(
 					'boldgrid_backup_upgrade_crontab_entries_complete',
 					$this->crontab_version

--- a/admin/class-boldgrid-backup-admin-cron.php
+++ b/admin/class-boldgrid-backup-admin-cron.php
@@ -204,7 +204,12 @@ class Boldgrid_Backup_Admin_Cron {
 	public function add_all_crons( array $settings ) {
 		$success = false;
 
-		$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+		/*
+		 * Prefer the saved setting, then the same fallback as scheduler->get() /
+		 * auto-rollback. Using only settings['scheduler'] would no-op when the key
+		 * was never saved even though system cron is the effective scheduler.
+		 */
+		$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : $this->core->scheduler->get();
 		$schedule  = ! empty( $settings['schedule'] ) ? $settings['schedule'] : null;
 
 		if ( 'cron' === $scheduler && $this->core->scheduler->is_available( $scheduler ) ) {
@@ -1212,7 +1217,12 @@ class Boldgrid_Backup_Admin_Cron {
 		 */
 		update_site_option( self::SECRETS_ROTATED_OPTION, self::SECRETS_ROTATED_VERSION );
 
-		$settings  = $this->core->settings->get_settings( true );
+		$settings = $this->core->settings->get_settings( true );
+		/*
+		 * Use scheduler->get() so a missing settings['scheduler'] still resolves via the
+		 * same fallback as auto-rollback. Reading the raw key left pending rollbacks
+		 * without a cancel re-issue and skipped crontab rewrite after remint.
+		 */
 		$scheduler = $this->core->scheduler->get();
 
 		if ( $rotating && 'cron' === $scheduler && $this->core->scheduler->is_available( 'cron' ) ) {
@@ -1556,7 +1566,8 @@ class Boldgrid_Backup_Admin_Cron {
 		$upgraded = false;
 		$settings = $this->core->settings->get_settings( true );
 
-		$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+		// Match auto-rollback / rotation: fall back when settings never saved a scheduler.
+		$scheduler = $this->core->scheduler->get();
 
 		if ( 'cron' !== $scheduler || ! $this->core->scheduler->is_available( $scheduler ) ) {
 			return false;

--- a/admin/cron/class-crontab.php
+++ b/admin/cron/class-crontab.php
@@ -86,6 +86,22 @@ class Crontab {
 	 * @return bool
 	 */
 	public function write_crontab( $crontab ) {
+		/**
+		 * Filter whether the system crontab may be replaced.
+		 *
+		 * This is the only place the plugin rewrites the crontab, so returning false here
+		 * makes every scheduling path a no-op. The test suite uses this so a run cannot
+		 * overwrite the crontab of the account running it.
+		 *
+		 * @since 1.17.4
+		 *
+		 * @param bool   $can_write Whether the crontab may be written.
+		 * @param string $crontab   The crontab contents that would be written.
+		 */
+		if ( ! apply_filters( 'boldgrid_backup_can_write_crontab', true, $crontab ) ) {
+			return false;
+		}
+
 		$backup_directory = $this->core->backup_dir->get();
 
 		if ( ! $this->core->wp_filesystem->is_writable( $backup_directory ) ) {

--- a/boldgrid-backup.php
+++ b/boldgrid-backup.php
@@ -16,7 +16,7 @@
  *          Plugin Name: Total Upkeep
  *          Plugin URI: https://www.boldgrid.com/boldgrid-backup/
  *          Description: Automated backups, remote backup to Amazon S3 and Google Drive, stop website crashes before they happen and more. Total Upkeep is the backup solution you need.
- *          Version: 1.17.3
+ *          Version: 1.17.4
  *          Author: BoldGrid
  *          Author URI: https://www.boldgrid.com/
  *          License: GPL-2.0+

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0cae8c81717101658bc1b9daff916511",
+    "content-hash": "2de3161698d0805a63e845c5fdec31f0",
     "packages": [
         {
             "name": "boldgrid/library",
@@ -2242,7 +2242,9 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=7.4"
+    },
     "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -93,6 +93,9 @@ class Boldgrid_Backup_Activator {
 				}
 			} elseif ( 'wp-cron' === $scheduler ) {
 				$core->wp_cron->add_all_crons( $settings );
+				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+					$core->wp_cron->add_restore_cron();
+				}
 			}
 		}
 	}

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -89,6 +89,16 @@ class Boldgrid_Backup_Activator {
 			$archives = $core->get_archive_list();
 			if ( 'cron' === $scheduler ) {
 				$core->cron->add_all_crons( $settings );
+
+				/*
+				 * add_all_crons clears every crontab entry, including an active direct-transfer
+				 * job that is managed separately. Reschedule it so an in-progress transfer is
+				 * not left stalled after activation (the same follow-up rotation already does).
+				 */
+				if ( $core->cron->has_active_direct_transfer() ) {
+					$core->cron->schedule_direct_transfer();
+				}
+
 				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 					$core->cron->add_restore_cron();
 				}

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -73,14 +73,24 @@ class Boldgrid_Backup_Activator {
 				\Boldgrid\Backup\Cli\Info::ensure_secure_storage( $backup_dir );
 			}
 
+			// Invalidate any previously exposable cron / CLI cancel secrets once.
+			$core->cron->maybe_rotate_cron_secrets();
+
 			/*
 			 * Add all previous crons.
 			 *
 			 * The add_all_crons methods called include proper checks to ensure
 			 * scheduler is available and $settings include a schedule.
+			 *
+			 * Re-read settings after secret rotation so crontab lines embed the new secret.
+			 * add_all_crons clears schedules, so re-add a pending rollback restore cron after.
 			 */
+			$settings = $core->settings->get_settings();
 			if ( 'cron' === $scheduler ) {
 				$core->cron->add_all_crons( $settings );
+				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+					$core->cron->add_restore_cron();
+				}
 			} elseif ( 'wp-cron' === $scheduler ) {
 				$core->wp_cron->add_all_crons( $settings );
 			}

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -90,15 +90,6 @@ class Boldgrid_Backup_Activator {
 			if ( 'cron' === $scheduler ) {
 				$core->cron->add_all_crons( $settings );
 
-				/*
-				 * add_all_crons clears every crontab entry, including an active direct-transfer
-				 * job that is managed separately. Reschedule it so an in-progress transfer is
-				 * not left stalled after activation (the same follow-up rotation already does).
-				 */
-				if ( $core->cron->has_active_direct_transfer() ) {
-					$core->cron->schedule_direct_transfer();
-				}
-
 				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 					$core->cron->add_restore_cron();
 				}
@@ -107,6 +98,16 @@ class Boldgrid_Backup_Activator {
 				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 					$core->wp_cron->add_restore_cron();
 				}
+			}
+
+			/*
+			 * Direct transfer uses system crontab regardless of backup scheduler. add_all_crons
+			 * on the system-cron path clears that entry; on the wp-cron path the harvested-secret
+			 * line would otherwise remain after rotation. Delete then reschedule when active.
+			 */
+			if ( $core->cron->has_active_direct_transfer() ) {
+				$core->cron->entry_delete_contains( 'direct-transfer.php' );
+				$core->cron->schedule_direct_transfer();
 			}
 		}
 	}

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -79,11 +79,11 @@ class Boldgrid_Backup_Activator {
 			/*
 			 * Add all previous crons.
 			 *
-			 * The add_all_crons methods called include proper checks to ensure
-			 * scheduler is available and $settings include a schedule.
+			 * add_all_crons checks that the scheduler is available, then clears existing
+			 * schedules and only re-adds a backup entry when $settings include a schedule.
 			 *
 			 * Re-read settings after secret rotation so crontab lines embed the new secret.
-			 * add_all_crons clears schedules, so re-add a pending rollback restore cron after.
+			 * Since add_all_crons clears schedules, re-add a pending rollback restore cron after.
 			 */
 			$settings = $core->settings->get_settings();
 			if ( 'cron' === $scheduler ) {

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -86,14 +86,15 @@ class Boldgrid_Backup_Activator {
 			 * Since add_all_crons clears schedules, re-add a pending rollback restore cron after.
 			 */
 			$settings = $core->settings->get_settings();
+			$archives = $core->get_archive_list();
 			if ( 'cron' === $scheduler ) {
 				$core->cron->add_all_crons( $settings );
-				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 					$core->cron->add_restore_cron();
 				}
 			} elseif ( 'wp-cron' === $scheduler ) {
 				$core->wp_cron->add_all_crons( $settings );
-				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) ) {
+				if ( get_site_option( 'boldgrid_backup_pending_rollback' ) && ! empty( $archives ) ) {
 					$core->wp_cron->add_restore_cron();
 				}
 			}

--- a/includes/class-boldgrid-backup-activator.php
+++ b/includes/class-boldgrid-backup-activator.php
@@ -62,9 +62,9 @@ class Boldgrid_Backup_Activator {
 		self::$just_activated = true;
 
 		if ( Boldgrid_Backup_Admin_Test::is_filesystem_supported() ) {
-			$core      = new Boldgrid_Backup_Admin_Core();
-			$settings  = $core->settings->get_settings();
-			$scheduler = ! empty( $settings['scheduler'] ) ? $settings['scheduler'] : null;
+			$core = new Boldgrid_Backup_Admin_Core();
+			// Fall back when settings never saved a scheduler (same as auto-rollback).
+			$scheduler = $core->scheduler->get();
 
 			// Ensure per-install CLI secret lives outside the web-served plugin directory.
 			$backup_dir = $core->backup_dir->get();

--- a/includes/class-boldgrid-backup.php
+++ b/includes/class-boldgrid-backup.php
@@ -517,6 +517,9 @@ class Boldgrid_Backup {
 
 		$this->loader->add_action( 'admin_init', $plugin_admin_core->cron, 'upgrade_crontab_entries' );
 
+		// Rotate previously exposable cron secrets once on upgrade (not admin-only).
+		$this->loader->add_action( 'init', $plugin_admin_core->cron, 'maybe_rotate_cron_secrets', 1 );
+
 		$this->loader->add_action( 'admin_init', $plugin_admin_core, 'ensure_secure_cli_storage', 5 );
 
 		$this->loader->add_action( 'wp_ajax_boldgrid_backup_generate_download_link', $plugin_admin_core->archive_actions, 'wp_ajax_generate_download_link' );

--- a/includes/class-boldgrid-backup.php
+++ b/includes/class-boldgrid-backup.php
@@ -517,8 +517,16 @@ class Boldgrid_Backup {
 
 		$this->loader->add_action( 'admin_init', $plugin_admin_core->cron, 'upgrade_crontab_entries' );
 
-		// Rotate previously exposable cron secrets once on upgrade (not admin-only).
-		$this->loader->add_action( 'init', $plugin_admin_core->cron, 'maybe_rotate_cron_secrets', 1 );
+		/*
+		 * Rotate previously exposable cron secrets once on upgrade (not admin-only).
+		 *
+		 * Call directly rather than hooking init: run_boldgrid_backup() itself is
+		 * deferred to init priority 1, so registering another init:1 callback here
+		 * would miss the current request (WP does not invoke same-priority callbacks
+		 * added while that priority is already firing). Silent upgrades never hit
+		 * the activator, so this must run on the first admin/cron/CLI/REST boot.
+		 */
+		$plugin_admin_core->cron->maybe_rotate_cron_secrets();
 
 		$this->loader->add_action( 'admin_init', $plugin_admin_core, 'ensure_secure_cli_storage', 5 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: backup, cloud backup, database backup, restore, wordpress backup
 Requires at least: 5.0
 Tested up to: 7.0
 Requires PHP: 7.4
-Stable tag: 1.17.3
+Stable tag: 1.17.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -131,6 +131,10 @@ Have a problem? First, take a look at our [Getting Started](https://www.boldgrid
 1. Activate the plugin through the Plugins menu in WordPress.
 
 == Changelog ==
+
+= 1.17.4 =
+Release Date: Jul 30, 2026
+* Security Update: Rotate stored cron and CLI cancel secrets on upgrade so previously exposed credentials are no longer valid. Thanks to Jakub Herman for responsibly reporting this issue.
 
 = 1.17.3 =
 Release Date: Jul 23, 2026
@@ -968,6 +972,9 @@ Release Date: June 21st, 2016
 * Initial public release.
 
 == Upgrade Notice ==
+
+= 1.17.4 =
+Security update recommended for all users. Rotates stored secrets on upgrade.
 
 = 1.17.3 =
 Security update recommended for all users.

--- a/tests/admin/test-class-boldgrid-backup-admin-auto-updates.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-auto-updates.php
@@ -71,10 +71,20 @@ class Test_Boldgrid_Backup_Admin_Auto_Updates extends WP_UnitTestCase {
 
 		$url      = isset( $plugin_info->versions[ $version ] ) ? $plugin_info->versions[ $version ] : '';
 		$zip_file = ! empty( $url ) ? download_url( $url ) : '';
+
+		if ( is_wp_error( $zip_file ) ) {
+			$this->fail( 'Unable to download ' . $slug . ' ' . $version . ': ' . $zip_file->get_error_message() );
+		}
+
 		if ( true === is_dir( ABSPATH . 'wp-content/plugins/' . $slug ) ) {
 			$deleted = $wp_filesystem->delete( $this_plugin_dir, true );
 		}
 		$unzip = ! empty( $zip_file ) ? unzip_file( $zip_file, ABSPATH . 'wp-content/plugins/' ) : false;
+
+		if ( ! empty( $zip_file ) && file_exists( $zip_file ) ) {
+			unlink( $zip_file );
+		}
+
 		return $unzip;
 	}
 

--- a/tests/admin/test-class-boldgrid-backup-admin-auto-updates.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-auto-updates.php
@@ -105,12 +105,13 @@ class Test_Boldgrid_Backup_Admin_Auto_Updates extends WP_UnitTestCase {
 		);
 
 		$installed_themes = wp_get_themes();
-		$theme_slug       = 'twentytwentytwo'; // Replace with your desired theme slug
-		$installed        = isset( $installed_themes[$theme_slug] );
+		$theme_slug       = 'twentytwentytwo';
+		$installed        = isset( $installed_themes[ $theme_slug ] );
 
 		if ( ! $installed ) {
-			$upgrader  = new Theme_Upgrader();
-			$installed = $upgrader->install("https://downloads.wordpress.org/theme/{$theme_slug}.latest-stable.zip");
+			// Use Automatic_Upgrader_Skin so Theme_Upgrader does not echo HTML or leave output buffers open (PHPUnit marks that as a risky test).
+			$upgrader  = new Theme_Upgrader( new Automatic_Upgrader_Skin() );
+			$installed = $upgrader->install( "https://downloads.wordpress.org/theme/{$theme_slug}.latest-stable.zip" );
 		}
 	}
 

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -979,4 +979,79 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 ';
 		$this->assertEquals( $crontab_expected, $crontab_filtered );
 	}
+
+	/**
+	 * upgrade_crontab_entries must re-add a pending rollback after add_all_crons clears.
+	 *
+	 * When crontab_version is missing and there is no backup schedule, add_all_crons
+	 * clears plugin crontab lines. The follow-up must call add_restore_cron so the
+	 * cancel secret is reminted (observable even when crontab writes are blocked).
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_upgrade_crontab_entries_reissues_pending_rollback() {
+		$this->maybe_create_backup();
+
+		// Force the system-cron path so this assertion does not depend on host crontab probes.
+		$this->core->scheduler->available = array(
+			'cron' => array(
+				'title' => 'Cron',
+			),
+		);
+
+		$settings = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		$settings['scheduler'] = 'cron';
+		unset( $settings['schedule'], $settings['crontab_version'] );
+		update_site_option( 'boldgrid_backup_settings', $settings );
+
+		$old_cancel_secret = 'cancel_secret_before_crontab_upgrade';
+		update_site_option( 'boldgrid_backup_cli_cancel_secret', $old_cancel_secret );
+		update_site_option( 'boldgrid_backup_pending_rollback', array( 'deadline' => time() + 300 ) );
+
+		$this->core->cron->upgrade_crontab_entries();
+
+		$new_cancel_secret = get_site_option( 'boldgrid_backup_cli_cancel_secret', '' );
+		delete_site_option( 'boldgrid_backup_pending_rollback' );
+
+		$this->assertNotEmpty( $new_cancel_secret );
+		$this->assertNotEquals(
+			$old_cancel_secret,
+			$new_cancel_secret,
+			'Pending rollback restore cron must be re-issued after upgrade_crontab_entries.'
+		);
+	}
+
+	/**
+	 * upgrade_crontab_entries must not schedule a system restore cron for wp-cron sites.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_upgrade_crontab_entries_skips_system_restore_for_wp_cron() {
+		$this->maybe_create_backup();
+
+		$settings = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		$settings['scheduler'] = 'wp-cron';
+		unset( $settings['schedule'], $settings['crontab_version'] );
+		update_site_option( 'boldgrid_backup_settings', $settings );
+
+		$old_cancel_secret = 'cancel_secret_wp_cron_must_keep';
+		update_site_option( 'boldgrid_backup_cli_cancel_secret', $old_cancel_secret );
+		update_site_option( 'boldgrid_backup_pending_rollback', array( 'deadline' => time() + 300 ) );
+
+		$this->core->cron->upgrade_crontab_entries();
+
+		delete_site_option( 'boldgrid_backup_pending_rollback' );
+
+		$this->assertSame(
+			$old_cancel_secret,
+			get_site_option( 'boldgrid_backup_cli_cancel_secret', '' ),
+			'wp-cron sites must not get a system restore cron from upgrade_crontab_entries.'
+		);
+	}
 }

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -212,6 +212,122 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test one-time rotation clears stored secrets and mints a new cron_secret.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_rotates_once() {
+		$old_secret = 'leaked_cron_secret_from_pre_1_17_3';
+		$settings   = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		$settings['cron_secret'] = $old_secret;
+		update_site_option( 'boldgrid_backup_settings', $settings );
+		update_site_option( 'boldgrid_backup_cli_cancel_secret', 'old_cli_cancel_secret' );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		// Ensure in-memory cache does not short-circuit rotation.
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, $old_secret );
+
+		$ran = $this->core->cron->maybe_rotate_cron_secrets();
+		$this->assertTrue( $ran );
+
+		$new_secret = $this->core->cron->get_cron_secret();
+		$this->assertNotEmpty( $new_secret );
+		$this->assertNotEquals( $old_secret, $new_secret );
+		$this->assertFalse(
+			hash_equals( $old_secret, $new_secret ),
+			'Harvested pre-upgrade secret must no longer match the stored cron_secret.'
+		);
+		$this->assertFalse( get_site_option( 'boldgrid_backup_cli_cancel_secret', false ) );
+		$this->assertSame(
+			Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_VERSION,
+			get_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION )
+		);
+
+		// Second call is a no-op and must not rotate again.
+		$second_ran = $this->core->cron->maybe_rotate_cron_secrets();
+		$this->assertFalse( $second_ran );
+		$this->assertSame( $new_secret, $this->core->cron->get_cron_secret() );
+	}
+
+	/**
+	 * Test greenfield installs with no prior secret only set the rotation gate.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_greenfield_sets_flag_only() {
+		$settings = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		unset( $settings['cron_secret'] );
+		update_site_option( 'boldgrid_backup_settings', $settings );
+		delete_site_option( 'boldgrid_backup_cli_cancel_secret' );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, null );
+
+		$ran = $this->core->cron->maybe_rotate_cron_secrets();
+		$this->assertTrue( $ran );
+		$this->assertSame(
+			Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_VERSION,
+			get_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION )
+		);
+
+		// No secret should have been minted solely by the greenfield gate.
+		$settings_after = get_site_option( 'boldgrid_backup_settings', array() );
+		$this->assertTrue( empty( $settings_after['cron_secret'] ) );
+	}
+
+	/**
+	 * Test restore-info JSON is rewritten to the new cron_secret after rotation.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_refresh_restore_info_cron_secret() {
+		$backup_dir = $this->core->backup_dir->get();
+		$this->assertNotEmpty( $backup_dir );
+
+		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
+		$storage = \Boldgrid\Backup\Cli\Info::ensure_secure_storage( $backup_dir );
+		$this->assertNotEmpty( $storage );
+
+		$cli_secret = \Boldgrid\Backup\Cli\Info::get_secret();
+		$this->assertTrue( \Boldgrid\Backup\Cli\Info::is_valid_secret_format( $cli_secret ) );
+
+		$old_secret = 'old_restore_info_cron_secret';
+		$new_secret = 'new_restore_info_cron_secret';
+		$path       = trailingslashit( $storage ) . 'restore-info-' . $cli_secret . '.json';
+
+		$payload = wp_json_encode(
+			array(
+				'cron_secret' => $old_secret,
+				'filepath'    => '/tmp/example.zip',
+				'restore_cmd' => 'php -qf "boldgrid-backup-cron.php" mode=restore secret=' . $old_secret . ' archive_key=0',
+			)
+		);
+		$this->assertNotFalse( file_put_contents( $path, $payload ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		$updated = $this->core->cron->refresh_restore_info_cron_secret( $old_secret, $new_secret );
+		$this->assertTrue( $updated );
+
+		$decoded = json_decode( file_get_contents( $path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		$this->assertSame( $new_secret, $decoded['cron_secret'] );
+		$this->assertStringContainsString( 'secret=' . $new_secret, $decoded['restore_cmd'] );
+		$this->assertStringNotContainsString( 'secret=' . $old_secret, $decoded['restore_cmd'] );
+
+		@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions
+	}
+
+	/**
 	 * Test filtering crontab contents with mode "" (backup).
 	 *
 	 * @since 1.11.1

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -309,6 +309,48 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A pending rollback must keep a usable cancel secret even with no cron_secret to rotate.
+	 *
+	 * The CLI cancel secret is minted independently of cron_secret, so clearing it without
+	 * re-issuing the restore cron would leave the rollback running and uncancellable.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_reissues_cancel_secret_without_old_cron_secret() {
+		$this->maybe_create_backup();
+
+		$settings = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		unset( $settings['cron_secret'] );
+		$settings['scheduler'] = 'cron';
+		update_site_option( 'boldgrid_backup_settings', $settings );
+
+		$old_cancel_secret = 'cancel_secret_from_pre_upgrade';
+		update_site_option( 'boldgrid_backup_cli_cancel_secret', $old_cancel_secret );
+		update_site_option( 'boldgrid_backup_pending_rollback', array( 'deadline' => time() + 300 ) );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, null );
+
+		$this->assertTrue( $this->core->cron->maybe_rotate_cron_secrets() );
+
+		$new_cancel_secret = get_site_option( 'boldgrid_backup_cli_cancel_secret', '' );
+
+		delete_site_option( 'boldgrid_backup_pending_rollback' );
+
+		$this->assertNotEmpty(
+			$new_cancel_secret,
+			'A pending rollback must be left with a usable cancel secret.'
+		);
+		$this->assertNotEquals( $old_cancel_secret, $new_cancel_secret );
+	}
+
+	/**
 	 * Test greenfield installs with no prior secret only set the rotation gate.
 	 *
 	 * @since 1.17.4

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -283,15 +283,16 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 		$property->setValue( $this->core->cron, $old_secret );
 
 		/*
-		 * Force add_all_crons to fail after remint by pointing backup_dir at a missing path
-		 * (update_cron bails when backup dir is empty/unavailable).
+		 * Crontab writes are blocked suite-wide by the bootstrap, so add_all_crons() cannot
+		 * succeed here. Assert that precondition so this test cannot silently stop covering
+		 * the failed-rewrite path.
 		 */
-		$original_dir                             = $this->core->backup_dir->backup_directory;
-		$this->core->backup_dir->backup_directory = '/nonexistent/path/that/does/not/exist';
+		$this->assertFalse(
+			( new \Boldgrid\Backup\Admin\Cron\Crontab() )->write_crontab( '# no-op' ),
+			'Crontab writes must be blocked for this test to cover a failed rewrite.'
+		);
 
 		$ran = $this->core->cron->maybe_rotate_cron_secrets();
-
-		$this->core->backup_dir->backup_directory = $original_dir;
 
 		$this->assertTrue( $ran );
 		$this->assertSame(
@@ -420,6 +421,114 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'secret=' . $old_secret, $decoded['restore_cmd'] );
 
 		@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions
+	}
+
+	/**
+	 * Takeover recovery must refresh restore-info even when the prior cron_secret is gone.
+	 *
+	 * After a failed request clears settings['cron_secret'], refresh cannot match by the old
+	 * value. An empty $old_secret must rewrite any file still holding a different secret.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_refresh_restore_info_cron_secret_rewrites_without_old_secret() {
+		$backup_dir = $this->core->backup_dir->get();
+		$this->assertNotEmpty( $backup_dir );
+
+		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
+		$storage = \Boldgrid\Backup\Cli\Info::ensure_secure_storage( $backup_dir );
+		$this->assertNotEmpty( $storage );
+
+		$cli_secret = \Boldgrid\Backup\Cli\Info::get_secret();
+		$this->assertTrue( \Boldgrid\Backup\Cli\Info::is_valid_secret_format( $cli_secret ) );
+
+		$harvested  = 'harvested_secret_unknown_to_takeover';
+		$new_secret = 'takeover_recovery_cron_secret';
+		$path       = trailingslashit( $storage ) . 'restore-info-' . $cli_secret . '.json';
+
+		$payload = wp_json_encode(
+			array(
+				'cron_secret' => $harvested,
+				'filepath'    => '/tmp/example.zip',
+				'restore_cmd' => 'php -qf "boldgrid-backup-cron.php" mode=restore secret=' . $harvested . ' archive_key=0',
+			)
+		);
+		$this->assertNotFalse( file_put_contents( $path, $payload ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		$updated = $this->core->cron->refresh_restore_info_cron_secret( '', $new_secret );
+		$this->assertTrue( $updated );
+
+		$decoded = json_decode( file_get_contents( $path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		$this->assertSame( $new_secret, $decoded['cron_secret'] );
+		$this->assertStringContainsString( 'secret=' . $new_secret, $decoded['restore_cmd'] );
+		$this->assertStringNotContainsString( 'secret=' . $harvested, $decoded['restore_cmd'] );
+
+		@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions
+	}
+
+	/**
+	 * Abandoned-claim takeover must rewrite restore-info after settings lost the old secret.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_takeover_refreshes_restore_info() {
+		$backup_dir = $this->core->backup_dir->get();
+		$this->assertNotEmpty( $backup_dir );
+
+		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
+		$storage = \Boldgrid\Backup\Cli\Info::ensure_secure_storage( $backup_dir );
+		$this->assertNotEmpty( $storage );
+
+		$cli_secret = \Boldgrid\Backup\Cli\Info::get_secret();
+		$this->assertTrue( \Boldgrid\Backup\Cli\Info::is_valid_secret_format( $cli_secret ) );
+
+		$harvested = 'harvested_secret_left_in_restore_info';
+		$path      = trailingslashit( $storage ) . 'restore-info-' . $cli_secret . '.json';
+		$payload   = wp_json_encode(
+			array(
+				'cron_secret' => $harvested,
+				'filepath'    => '/tmp/example.zip',
+				'restore_cmd' => 'php -qf "boldgrid-backup-cron.php" mode=restore secret=' . $harvested . ' archive_key=0',
+			)
+		);
+		$this->assertNotFalse( file_put_contents( $path, $payload ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		/*
+		 * Simulate a request that died after clearing secrets but before the gate / restore-info
+		 * rewrite: settings no longer hold the harvested value, yet restore-info still does.
+		 */
+		$settings = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		unset( $settings['cron_secret'] );
+		$settings['scheduler'] = 'cron';
+		update_site_option( 'boldgrid_backup_settings', $settings );
+		delete_site_option( 'boldgrid_backup_cli_cancel_secret' );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, null );
+
+		update_site_option(
+			Boldgrid_Backup_Admin_Cron::SECRETS_ROTATING_OPTION,
+			time() - ( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATING_TIMEOUT + 1 )
+		);
+
+		$this->assertTrue( $this->core->cron->maybe_rotate_cron_secrets() );
+
+		$new_secret = $this->core->cron->get_cron_secret();
+		$decoded    = json_decode( file_get_contents( $path ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions
+
+		$this->assertNotEmpty( $new_secret );
+		$this->assertIsArray( $decoded );
+		$this->assertSame( $new_secret, $decoded['cron_secret'] );
+		$this->assertStringContainsString( 'secret=' . $new_secret, $decoded['restore_cmd'] );
+		$this->assertStringNotContainsString( 'secret=' . $harvested, $decoded['restore_cmd'] );
 	}
 
 	/**

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -233,6 +233,16 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 		$property->setAccessible( true );
 		$property->setValue( $this->core->cron, $old_secret );
 
+		$backup_id      = $this->core->get_backup_identifier();
+		$_GET['id']     = $backup_id;
+		$_GET['secret'] = $old_secret;
+		wp_set_current_user( 0 );
+
+		$this->assertTrue(
+			$this->core->cron->is_valid_call(),
+			'Pre-rotation secret must still authorize before upgrade rotation runs.'
+		);
+
 		$ran = $this->core->cron->maybe_rotate_cron_secrets();
 		$this->assertTrue( $ran );
 
@@ -248,6 +258,18 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 			Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_VERSION,
 			get_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION )
 		);
+
+		$_GET['secret'] = $old_secret;
+		$this->assertFalse(
+			$this->core->cron->is_valid_call(),
+			'Harvested pre-upgrade secret must be rejected after rotation.'
+		);
+		$_GET['secret'] = $new_secret;
+		$this->assertTrue(
+			$this->core->cron->is_valid_call(),
+			'Fresh post-rotation secret must authorize legitimate cron calls.'
+		);
+		unset( $_GET['id'], $_GET['secret'] );
 
 		// Second call is a no-op and must not rotate again.
 		$second_ran = $this->core->cron->maybe_rotate_cron_secrets();

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -1054,4 +1054,55 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 			'wp-cron sites must not get a system restore cron from upgrade_crontab_entries.'
 		);
 	}
+
+	/**
+	 * Rotation must use scheduler->get() fallback when settings never saved a scheduler.
+	 *
+	 * Auto-rollback schedules via the fallback. Reading only settings['scheduler'] would
+	 * skip restore re-issue after clearing cli_cancel_secret on those sites.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_uses_scheduler_fallback() {
+		$this->maybe_create_backup();
+
+		$this->core->scheduler->available = array(
+			'cron' => array(
+				'title' => 'Cron',
+			),
+		);
+
+		$old_secret = 'secret_with_no_scheduler_setting';
+		$settings   = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		$settings['cron_secret'] = $old_secret;
+		unset( $settings['scheduler'] );
+		update_site_option( 'boldgrid_backup_settings', $settings );
+
+		$old_cancel_secret = 'cancel_secret_before_scheduler_fallback';
+		update_site_option( 'boldgrid_backup_cli_cancel_secret', $old_cancel_secret );
+		update_site_option( 'boldgrid_backup_pending_rollback', array( 'deadline' => time() + 300 ) );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, $old_secret );
+
+		$this->assertSame( 'cron', $this->core->scheduler->get() );
+		$this->assertTrue( $this->core->cron->maybe_rotate_cron_secrets() );
+
+		$new_cancel_secret = get_site_option( 'boldgrid_backup_cli_cancel_secret', '' );
+		delete_site_option( 'boldgrid_backup_pending_rollback' );
+
+		$this->assertNotEmpty( $new_cancel_secret );
+		$this->assertNotEquals(
+			$old_cancel_secret,
+			$new_cancel_secret,
+			'Fallback system-cron sites must re-issue the pending rollback cancel secret.'
+		);
+		$this->assertNotEquals( $old_secret, $this->core->cron->get_cron_secret() );
+	}
 }

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -674,6 +674,100 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 	}
 
 	/**
+	 * has_active_direct_transfer must tolerate missing status and match migrate status values.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_has_active_direct_transfer() {
+		$config       = $this->core->configs['direct_transfer'];
+		$option_names = $config['option_names'];
+		$transfer_id  = 'xfer_status_guard_test';
+
+		delete_option( $option_names['active_transfer'] );
+		delete_option( $option_names['active_tx'] );
+		delete_option( $option_names['transfers'] );
+
+		$this->assertFalse( $this->core->cron->has_active_direct_transfer() );
+
+		update_option( $option_names['active_transfer'], $transfer_id, false );
+		update_option(
+			$option_names['transfers'],
+			array(
+				$transfer_id => array(
+					'transfer_id' => $transfer_id,
+					'status'      => 'transferring',
+				),
+			),
+			false
+		);
+		$this->assertTrue( $this->core->cron->has_active_direct_transfer() );
+
+		// Missing status must not warn/fatal; treat as active so upgrade cannot drop the cron.
+		update_option(
+			$option_names['transfers'],
+			array(
+				$transfer_id => array(
+					'transfer_id' => $transfer_id,
+				),
+			),
+			false
+		);
+		$this->assertTrue( $this->core->cron->has_active_direct_transfer() );
+
+		// Migrate writes "canceled"; also accept the historical "cancelled" spelling.
+		update_option(
+			$option_names['transfers'],
+			array(
+				$transfer_id => array(
+					'transfer_id' => $transfer_id,
+					'status'      => 'canceled',
+				),
+			),
+			false
+		);
+		$this->assertFalse( $this->core->cron->has_active_direct_transfer() );
+
+		update_option(
+			$option_names['transfers'],
+			array(
+				$transfer_id => array(
+					'transfer_id' => $transfer_id,
+					'status'      => 'cancelled',
+				),
+			),
+			false
+		);
+		$this->assertFalse( $this->core->cron->has_active_direct_transfer() );
+
+		update_option(
+			$option_names['transfers'],
+			array(
+				$transfer_id => array(
+					'transfer_id' => $transfer_id,
+					'status'      => 'completed',
+				),
+			),
+			false
+		);
+		$this->assertFalse( $this->core->cron->has_active_direct_transfer() );
+
+		delete_option( $option_names['active_transfer'] );
+		delete_option( $option_names['transfers'] );
+
+		update_option(
+			$option_names['active_tx'],
+			array(
+				'transfer_id' => $transfer_id,
+				'status'      => 'pending',
+			),
+			false
+		);
+		$this->assertTrue( $this->core->cron->has_active_direct_transfer() );
+
+		delete_option( $option_names['active_tx'] );
+	}
+
+	/**
 	 * Test filtering crontab contents with mode "" (backup).
 	 *
 	 * @since 1.11.1

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -256,6 +256,59 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Gate must be set even when crontab rewrite fails, so the next init does not re-mint.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_sets_gate_when_crontab_rewrite_fails() {
+		$old_secret = 'secret_before_failed_crontab_rewrite';
+		$settings   = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		$settings['cron_secret'] = $old_secret;
+		$settings['scheduler']   = 'cron';
+		$settings['schedule']    = array(
+			'dow_monday' => 1,
+			'tod_h'      => 3,
+			'tod_m'      => '15',
+			'tod_a'      => 'AM',
+		);
+		update_site_option( 'boldgrid_backup_settings', $settings );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, $old_secret );
+
+		/*
+		 * Force add_all_crons to fail after remint by pointing backup_dir at a missing path
+		 * (update_cron bails when backup dir is empty/unavailable).
+		 */
+		$original_dir                             = $this->core->backup_dir->backup_directory;
+		$this->core->backup_dir->backup_directory = '/nonexistent/path/that/does/not/exist';
+
+		$ran = $this->core->cron->maybe_rotate_cron_secrets();
+
+		$this->core->backup_dir->backup_directory = $original_dir;
+
+		$this->assertTrue( $ran );
+		$this->assertSame(
+			Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_VERSION,
+			get_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION ),
+			'Gate must be set after remint even if crontab rewrite fails.'
+		);
+
+		$mid_secret = $this->core->cron->get_cron_secret();
+		$this->assertNotEquals( $old_secret, $mid_secret );
+
+		// A subsequent call must not rotate again.
+		$this->assertFalse( $this->core->cron->maybe_rotate_cron_secrets() );
+		$this->assertSame( $mid_secret, $this->core->cron->get_cron_secret() );
+	}
+
+	/**
 	 * Test greenfield installs with no prior secret only set the rotation gate.
 	 *
 	 * @since 1.17.4

--- a/tests/admin/test-class-boldgrid-backup-admin-cron.php
+++ b/tests/admin/test-class-boldgrid-backup-admin-cron.php
@@ -423,6 +423,148 @@ class Test_Boldgrid_Backup_Admin_Cron extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Write a legacy plugin-tree restore-info file holding the given cron secret.
+	 *
+	 * @since 1.17.4
+	 *
+	 * @param  string $cron_secret Cron secret to embed.
+	 * @return string Absolute path to the file written.
+	 */
+	private function write_legacy_restore_info( $cron_secret ) {
+		$path = BOLDGRID_BACKUP_PATH . '/cron/restore-info-' . str_repeat( 'a', 32 ) . '.json';
+
+		$payload = wp_json_encode(
+			array(
+				'cron_secret' => $cron_secret,
+				'filepath'    => '/tmp/example.zip',
+				'restore_cmd' => 'php -qf "boldgrid-backup-cron.php" mode=restore secret=' . $cron_secret . ' archive_key=0',
+			)
+		);
+
+		$this->assertNotFalse( file_put_contents( $path, $payload ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		return $path;
+	}
+
+	/**
+	 * A retired plugin-tree copy must be deleted rather than given the new secret.
+	 *
+	 * The CLI cannot reach it once secure storage exists, and the plugin tree is not a
+	 * guaranteed-private location, so the fresh secret must not be written there.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_refresh_restore_info_cron_secret_deletes_retired_legacy_copy() {
+		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
+		$this->assertNotEmpty( \Boldgrid\Backup\Cli\Info::ensure_secure_storage( $this->core->backup_dir->get() ) );
+
+		$old_secret = 'old_legacy_cron_restore_info_secret';
+		$path       = $this->write_legacy_restore_info( $old_secret );
+
+		$this->core->cron->refresh_restore_info_cron_secret( $old_secret, 'new_legacy_cron_restore_info_secret' );
+
+		$exists    = file_exists( $path );
+		$remaining = $exists ? file_get_contents( $path ) : ''; // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions
+
+		$this->assertFalse( $exists, 'A retired plugin-tree restore-info copy must be deleted.' );
+		$this->assertStringNotContainsString( 'new_legacy_cron_restore_info_secret', $remaining );
+	}
+
+	/**
+	 * A live plugin-tree copy must be rewritten so emergency restore keeps working.
+	 *
+	 * Sites where secure storage is unavailable keep their live restore metadata in the
+	 * plugin's cron/ directory, so skipping it would leave emergency CLI restore calling
+	 * admin-ajax with a secret that is no longer valid.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_refresh_restore_info_cron_secret_rewrites_live_legacy_copy() {
+		require_once BOLDGRID_BACKUP_PATH . '/cli/class-info.php';
+
+		$old_secret = 'old_live_legacy_cron_secret';
+		$new_secret = 'new_live_legacy_cron_secret';
+		$path       = $this->write_legacy_restore_info( $old_secret );
+
+		/*
+		 * Hide the restore locators so Info reports no secure storage, which is the state
+		 * that leaves the plugin tree serving as the live metadata location.
+		 */
+		$hidden = array();
+		foreach ( array( \Boldgrid\Backup\Cli\Info::get_restore_locator_filepath(), \Boldgrid\Backup\Cli\Info::get_wp_content_locator_filepath() ) as $locator ) {
+			if ( ! empty( $locator ) && file_exists( $locator ) && rename( $locator, $locator . '.test-bak' ) ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+				$hidden[] = $locator;
+			}
+		}
+
+		$updated = $this->core->cron->refresh_restore_info_cron_secret( $old_secret, $new_secret );
+
+		foreach ( $hidden as $locator ) {
+			rename( $locator . '.test-bak', $locator ); // phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename
+		}
+
+		$decoded = file_exists( $path ) ? json_decode( file_get_contents( $path ), true ) : null; // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions
+
+		$this->assertTrue( $updated );
+		$this->assertIsArray( $decoded, 'The live plugin-tree copy must be kept, not deleted.' );
+		$this->assertSame( $new_secret, $decoded['cron_secret'] );
+		$this->assertStringContainsString( 'secret=' . $new_secret, $decoded['restore_cmd'] );
+		$this->assertStringNotContainsString( 'secret=' . $old_secret, $decoded['restore_cmd'] );
+	}
+
+	/**
+	 * Rotation must not run while another request holds a fresh claim.
+	 *
+	 * Without the claim, two concurrent requests can both pass the gate check and remint,
+	 * leaving crontab and settings holding different secrets. An abandoned claim must
+	 * still be taken over so a request that died mid-rotation cannot block the upgrade.
+	 *
+	 * @since 1.17.4
+	 */
+	public function test_maybe_rotate_cron_secrets_respects_rotation_claim() {
+		$old_secret = 'secret_guarded_by_rotation_claim';
+		$settings   = get_site_option( 'boldgrid_backup_settings', array() );
+		if ( ! is_array( $settings ) ) {
+			$settings = array();
+		}
+		$settings['cron_secret'] = $old_secret;
+		update_site_option( 'boldgrid_backup_settings', $settings );
+		delete_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION );
+
+		$reflection = new ReflectionClass( $this->core->cron );
+		$property   = $reflection->getProperty( 'cron_secret' );
+		$property->setAccessible( true );
+		$property->setValue( $this->core->cron, $old_secret );
+
+		// Another request just claimed the rotation.
+		update_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATING_OPTION, time() );
+
+		$this->assertFalse( $this->core->cron->maybe_rotate_cron_secrets() );
+		$this->assertFalse( get_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATED_OPTION, false ) );
+
+		$settings_after = get_site_option( 'boldgrid_backup_settings', array() );
+		$this->assertSame(
+			$old_secret,
+			$settings_after['cron_secret'],
+			'A claimed rotation must not remint in a second request.'
+		);
+
+		// An abandoned claim must not block the upgrade forever.
+		update_site_option(
+			Boldgrid_Backup_Admin_Cron::SECRETS_ROTATING_OPTION,
+			time() - ( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATING_TIMEOUT + 1 )
+		);
+
+		$this->assertTrue( $this->core->cron->maybe_rotate_cron_secrets() );
+		$this->assertNotEquals( $old_secret, $this->core->cron->get_cron_secret() );
+		$this->assertFalse( get_site_option( Boldgrid_Backup_Admin_Cron::SECRETS_ROTATING_OPTION, false ) );
+	}
+
+	/**
 	 * Test filtering crontab contents with mode "" (backup).
 	 *
 	 * @since 1.11.1

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,25 @@ if ( ! $_tests_dir ) {
 require_once $_tests_dir . '/includes/functions.php';
 
 /*
+ * Give the suite a private temp directory.
+ *
+ * download_url() renames its download to the name given in the response's Content-Disposition
+ * header, so every account running these tests on one machine targets the same path (for
+ * example /tmp/akismet.4.0.zip). Because /tmp is sticky, the rename fails with EPERM once
+ * another user owns that file, and the resulting warning fails the test.
+ */
+if ( ! defined( 'WP_TEMP_DIR' ) ) {
+	$_bgbkup_temp_dir = rtrim( sys_get_temp_dir(), '/' ) . '/boldgrid-backup-tests-' .
+		( function_exists( 'posix_geteuid' ) ? posix_geteuid() : get_current_user() );
+
+	if ( ! is_dir( $_bgbkup_temp_dir ) ) {
+		mkdir( $_bgbkup_temp_dir, 0700, true );
+	}
+
+	define( 'WP_TEMP_DIR', $_bgbkup_temp_dir );
+}
+
+/*
  * Never replace the crontab of the account running the tests.
  *
  * Scheduling paths such as add_all_crons() operate on the real system crontab, so without

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,6 +18,15 @@ if ( ! $_tests_dir ) {
 
 require_once $_tests_dir . '/includes/functions.php';
 
+/*
+ * Never replace the crontab of the account running the tests.
+ *
+ * Scheduling paths such as add_all_crons() operate on the real system crontab, so without
+ * this any test that reaches them wipes the developer's entries and rewrites them using the
+ * test environment's siteurl (http://example.org) and secrets.
+ */
+tests_add_filter( 'boldgrid_backup_can_write_crontab', '__return_false' );
+
 if ( ! defined( 'BOLDGRID_BACKUP_PATH' ) ) {
 	define( 'BOLDGRID_BACKUP_PATH', dirname( dirname( __FILE__ ) ) );
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,6 +46,59 @@ if ( ! defined( 'WP_TEMP_DIR' ) ) {
  */
 tests_add_filter( 'boldgrid_backup_can_write_crontab', '__return_false' );
 
+/*
+ * Never write test archives into the backup directory of the site being developed against.
+ *
+ * Boldgrid_Backup_Admin_Backup_Dir::get() falls back to the account's boldgrid_backup
+ * directory, so archive, restore-info, log and compressor tests store hundreds of megabytes
+ * per run alongside a real site's backups. Point the suite at its own per-user directory
+ * instead; BGBKUP_TESTS_BACKUP_DIR overrides it.
+ */
+$_bgbkup_backup_dir = getenv( 'BGBKUP_TESTS_BACKUP_DIR' );
+if ( ! $_bgbkup_backup_dir ) {
+	$_bgbkup_home       = getenv( 'HOME' );
+	$_bgbkup_backup_dir = ( $_bgbkup_home ? $_bgbkup_home . '/tmp' : rtrim( sys_get_temp_dir(), '/' ) ) .
+		'/boldgrid-backup-tests-' .
+		( function_exists( 'posix_geteuid' ) ? posix_geteuid() : get_current_user() ) . '/backup-dir';
+}
+
+if ( ! is_dir( $_bgbkup_backup_dir ) ) {
+	mkdir( $_bgbkup_backup_dir, 0700, true );
+}
+
+$_bgbkup_backup_dir_filter = function( $settings ) use ( $_bgbkup_backup_dir ) {
+	$settings                     = is_array( $settings ) ? $settings : array();
+	$settings['backup_directory'] = $_bgbkup_backup_dir;
+
+	return $settings;
+};
+
+tests_add_filter( 'site_option_boldgrid_backup_settings', $_bgbkup_backup_dir_filter );
+
+/*
+ * Store the directory in the settings option as well.
+ *
+ * guess_and_set() used to persist this option as a side effect of falling back to the real
+ * directory, and code such as Boldgrid_Backup_Admin_Migrate_Util::get_option() queries
+ * wp_options directly, so filtering reads alone leaves it with no backup directory at all.
+ * The filter above is dropped for the write, otherwise update_site_option() compares against
+ * the filtered value, finds no change, and never creates the row.
+ */
+tests_add_filter(
+	'wp_loaded',
+	function() use ( $_bgbkup_backup_dir, $_bgbkup_backup_dir_filter ) {
+		remove_filter( 'site_option_boldgrid_backup_settings', $_bgbkup_backup_dir_filter );
+
+		$settings                     = get_site_option( 'boldgrid_backup_settings', array() );
+		$settings                     = is_array( $settings ) ? $settings : array();
+		$settings['backup_directory'] = $_bgbkup_backup_dir;
+
+		update_site_option( 'boldgrid_backup_settings', $settings );
+
+		add_filter( 'site_option_boldgrid_backup_settings', $_bgbkup_backup_dir_filter );
+	}
+);
+
 if ( ! defined( 'BOLDGRID_BACKUP_PATH' ) ) {
 	define( 'BOLDGRID_BACKUP_PATH', dirname( dirname( __FILE__ ) ) );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,9 +288,9 @@ boolify@^1.0.0:
   integrity sha512-ma2q0Tc760dW54CdOyJjhrg/a54317o1zYADQJFgperNGKIKgAUGIcKnuMiff8z57+yGlrGNEt4lPgZfCgTJgA==
 
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
-  version "1.1.16"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
-  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.18.tgz#3ce74d89885136be1535341f8c3d4425c29a5cab"
+  integrity sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"


### PR DESCRIPTION
https://imh-internal.atlassian.net/browse/ENG7-4653

## Summary
* On upgrade to **1.17.4**, rotate stored cron and CLI cancel secrets once so credentials that may have been exposed on older releases are no longer accepted.
* Refresh crontab entries and emergency restore-info that embed the prior cron secret so legitimate scheduled jobs keep working after rotation.
* Greenfield installs set a one-shot gate without unnecessary secret churn; version bump and changelog for 1.17.4.

## Test plan
- [ ] `wpphpunit --filter Test_Boldgrid_Backup_Admin_Cron` (includes new rotation / restore-info tests)
- [ ] Upgrade path 1.17.3 → 1.17.4: previously stored cron secret rejected; new secret authorizes legitimate cron backup/restore
- [ ] Confirm scheduled crontab lines use the new secret without a manual settings save
- [ ] Confirm CLI cancel secret option is cleared (and re-issued if a pending rollback restore cron exists)
- [ ] Fresh install: single mint on first use; rotation gate set without looping on every request
- [ ] Plugin Check / smoke install of 1.17.4 zip


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication for unauthenticated cron/CLI paths and rewrites system crontab and restore metadata on every site upgrading to 1.17.4; failures are mitigated but could briefly break scheduled backups or rollbacks until settings are saved again.
> 
> **Overview**
> **1.17.4** adds a one-time upgrade path that invalidates previously leakable **cron** and **CLI cancel** secrets, bumps the plugin version, and tightens cron scheduling so legitimate jobs survive rotation and crontab upgrades.
> 
> On first boot after upgrade (and on activation), `maybe_rotate_cron_secrets()` clears stored secrets, mints a new `cron_secret`, persists a one-shot gate before crontab/restore-info rewrites, and uses a claim/timeout so concurrent or crashed rotations cannot remint forever or leave crontab and settings out of sync. It refreshes **restore-info** JSON (secure storage vs legacy plugin-tree), re-runs `add_all_crons` when system cron is effective, re-issues pending rollback cancel secrets, and reschedules **direct-transfer** crontab lines that still embed the old secret.
> 
> **Cron bugfixes** use `scheduler->get()` when the scheduler was never saved, treat empty backup schedules as success when jobs are scheduled (so `crontab_version` is not stuck), and after `upgrade_crontab_entries` / activation re-add restore and direct-transfer crons that `add_all_crons` would otherwise wipe. `boldgrid_backup_can_write_crontab` blocks real crontab writes in tests; bootstrap isolates temp and backup dirs for safer PHPUnit runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7278bef011c84ffa9c13d4302e875666e9efe053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->